### PR TITLE
fix: remediate Flashpoint findings (Codex-authored)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.21
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.6
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.5
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -969,7 +969,7 @@ summary.total_objects_successful | numeric | | 1 |
 Get a list of detections \*The action uses legacy Detects API being deprecated. Please use the 'list epp alerts' action instead\*
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 This action supports filtering in order to retrieve a particular set of detections.
 
@@ -1099,7 +1099,7 @@ summary.total_objects_successful | numeric | | 1 |
 Get a list of epp alerts, replaces legacy Detects API
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 #### Action Parameters
 
@@ -1654,7 +1654,7 @@ action_result.parameter.comment | string | | |
 Get a list of alerts
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 This action supports filtering in order to retrieve a particular set of alerts.
 
@@ -1719,7 +1719,7 @@ action_result.parameter.include_hidden | numeric | | True |
 Lists Real Time Response sessions
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 This action supports filtering in order to retrieve a particular session.
 
@@ -1858,7 +1858,7 @@ summary.total_objects_successful | numeric | | 1 |
 Retrieve results of an active responder command executed on a single host
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 #### Action Parameters
 
@@ -1893,7 +1893,7 @@ summary.total_objects_successful | numeric | | 1 |
 Get a list of files for the specified RTR session
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 #### Action Parameters
 
@@ -2329,7 +2329,7 @@ summary.total_objects_successful | numeric | | 1 |
 Search for incidents by providing an FQL filter, sorting, and paging details
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 This action fetches incidents using pagination logic.
 
@@ -2832,7 +2832,7 @@ summary.total_objects_successful | numeric | | 1 |
 Queries for custom indicators in your customer account
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 #### Action Parameters
 
@@ -4235,7 +4235,7 @@ summary.total_objects_successful | numeric | | 1 |
 List IOA Rule Groups
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 #### Action Parameters
 

--- a/README.md
+++ b/README.md
@@ -4133,7 +4133,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **version** | required | Latest version of this Rule Group | numeric | |
 **name** | required | Name of the Rule Group | string | |
 **description** | required | Longer description for the Rule Group | string | |
-**enabled** | optional | Enable or disable the Rule Group | boolean | |
+**enabled** | optional | Enable or disable the Rule Group (omit to leave unchanged) | boolean | |
 **comment** | required | Comment for the audit log | string | |
 **assign_policy_id** | optional | Prevention Policy ID to assign the Rule Group to | string | `crowdstrike prevention policy id` |
 **remove_policy_id** | optional | Prevention Policy ID to remove the Rule Group from | string | `crowdstrike prevention policy id` |
@@ -4441,7 +4441,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **disposition_id** | required | The action that the rule should take when triggered (valid dispositions can be found in the "list ioa types" output) | numeric | |
 **field_values** | required | JSON list of parameters to pass to the new rule (valid fields can be found in the "list ioa types" output) | string | |
 **comment** | optional | Comment for the audit log (optional) | string | |
-**enabled** | optional | Enable this rule | boolean | |
+**enabled** | optional | Enable this rule (omit to leave unchanged) | boolean | |
 
 #### Action Output
 

--- a/README.md
+++ b/README.md
@@ -3101,6 +3101,8 @@ action_result.parameter.ioc | string | `hash` `sha256` `sha1` `md5` `domain` | e
 action_result.parameter.limit | numeric | | 100 |
 action_result.data.\*.falcon_process_id | string | `falcon process id` | pid:07c312fabcb8473454d0a16f118928fg:16716090292999 |
 action_result.summary.process_count | numeric | | 1 |
+action_result.summary.total_process_count | numeric | | 250 |
+action_result.summary.truncated | boolean | | True |
 action_result.message | string | | Process count: 1 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ No Output
 Run a query against CrowdStrike API
 
 Type: **investigate** <br>
-Read only: **True**
+Read only: **False**
 
 #### Action Parameters
 

--- a/README.md
+++ b/README.md
@@ -431,7 +431,6 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **collate** | optional | boolean | Merge containers for hostname and eventname |
 **merge_time_interval** | optional | numeric | Merge same containers within specified seconds |
 **max_crlf** | optional | numeric | Maximum allowed continuous blank lines |
-**preprocess_script** | optional | file | Script with functions to preprocess containers and artifacts |
 **detonate_timeout** | optional | numeric | Timeout for detonation result in minutes (Default: 15 minutes) |
 
 ### Supported Actions

--- a/README.md
+++ b/README.md
@@ -3632,7 +3632,6 @@ action_result.parameter.action_script | string | | default |
 action_result.parameter.command_line | string | | |
 action_result.parameter.comment | string | | This is a test comment |
 action_result.parameter.detail_report | boolean | | True False |
-action_result.parameter.document_password | password | | test_password |
 action_result.parameter.enable_tor | boolean | | True False |
 action_result.parameter.environment | string | `crowdstrike environment` | Windows 10, 64-bit |
 action_result.parameter.is_confidential | boolean | | True False |
@@ -3776,6 +3775,7 @@ action_result.summary.verdict | string | | suspicious |
 action_result.message | string | | Verdict: no specific threat, Total reports: 1 Total reports: 6 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.document_password | password | | |
 
 ## action: 'detonate url'
 
@@ -3808,7 +3808,6 @@ action_result.status | string | | success failed |
 action_result.parameter.action_script | string | | default |
 action_result.parameter.command_line | string | | |
 action_result.parameter.detail_report | boolean | | True False |
-action_result.parameter.document_password | password | | test_password |
 action_result.parameter.enable_tor | boolean | | True False |
 action_result.parameter.environment | string | `crowdstrike environment` | Windows 10, 64-bit |
 action_result.parameter.limit | numeric | | 5 |
@@ -3936,6 +3935,7 @@ action_result.summary.verdict | string | | suspicious |
 action_result.message | string | | Verdict: no specific threat, Total reports: 1 Total reports: 6 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.document_password | password | | |
 
 ## action: 'check status'
 

--- a/crowdstrike_assign_hosts.html
+++ b/crowdstrike_assign_hosts.html
@@ -107,7 +107,7 @@
             <td>Host Group ID</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ result.param.host_group_id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ result.param.host_group_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.host_group_id }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -119,7 +119,7 @@
               <td>Hostname</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['host name'], 'value': '{{ result.param.hostname }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['host name'], 'value': '{{ result.param.hostname|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.hostname }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -132,7 +132,7 @@
               <td>Device ID</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.device_id }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -163,7 +163,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ group.id }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ group.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ group.id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_command_output.html
+++ b/crowdstrike_command_output.html
@@ -127,7 +127,7 @@
               <td>Device ID</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.device_id }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -139,7 +139,7 @@
             <td>Session ID</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ result.param.session_id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ result.param.session_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.session_id }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -174,7 +174,7 @@
                           <td>
                             {% if result.summary.cloud_request_id %}
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike cloud request id'], 'value': '{{ result.summary.cloud_request_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike cloud request id'], 'value': '{{ result.summary.cloud_request_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ result.summary.cloud_request_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_create_ioa_rule.html
+++ b/crowdstrike_create_ioa_rule.html
@@ -131,7 +131,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.rulegroup_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.rulegroup_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.rulegroup_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -140,7 +140,7 @@
                           <td>{{ resource.magic_cookie }}</td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ resource.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ resource.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.instance_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_create_ioa_rule_group.html
+++ b/crowdstrike_create_ioa_rule_group.html
@@ -126,7 +126,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -167,7 +167,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ resource.id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -175,7 +175,7 @@
                             </td>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ policy_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_create_session.html
+++ b/crowdstrike_create_session.html
@@ -108,7 +108,7 @@
             <td>Device ID</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.device_id }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -136,7 +136,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ resource.session_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ resource.session_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.session_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -145,7 +145,7 @@
                           <td>{{ resource.created_at }}</td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ resource.pwd }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ resource.pwd|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.pwd }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_delete_indicator.html
+++ b/crowdstrike_delete_indicator.html
@@ -100,7 +100,7 @@ a:hover {
             {% if result.param.ioc %}
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': [ 'ip', 'ipv6', 'sha256', 'md5', 'domain' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': [ 'ip', 'ipv6', 'sha256', 'md5', 'domain' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.ioc }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -109,7 +109,7 @@ a:hover {
             {% if result.param.resource_id %}
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator id' ], 'value': '{{ result.param.resource_id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator id' ], 'value': '{{ result.param.resource_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.resource_id }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>

--- a/crowdstrike_detonate_file.html
+++ b/crowdstrike_detonate_file.html
@@ -119,7 +119,7 @@
                 <td>Vault ID</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.vault_id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -131,7 +131,7 @@
               <td>Environment Description</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.environment }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -198,7 +198,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -221,7 +221,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -233,7 +233,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -245,7 +245,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -257,7 +257,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -269,7 +269,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -281,7 +281,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -293,7 +293,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -305,7 +305,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -320,7 +320,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -338,7 +338,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -358,7 +358,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -379,7 +379,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_detonate_url.html
+++ b/crowdstrike_detonate_url.html
@@ -119,7 +119,7 @@
                 <td>URL</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.url }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -131,7 +131,7 @@
               <td>Environment Description</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.environment }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -198,7 +198,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -221,7 +221,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -233,7 +233,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -245,7 +245,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -257,7 +257,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -269,7 +269,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -281,7 +281,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -293,7 +293,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -305,7 +305,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -320,7 +320,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -338,7 +338,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -358,7 +358,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -379,7 +379,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_file_reputation.html
+++ b/crowdstrike_file_reputation.html
@@ -119,7 +119,7 @@
                 <td>Vault ID</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.vault_id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -188,7 +188,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -222,7 +222,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -234,7 +234,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -246,7 +246,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -258,7 +258,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -270,7 +270,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -282,7 +282,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -294,7 +294,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -306,7 +306,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -321,7 +321,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -339,7 +339,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -359,7 +359,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -380,7 +380,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_get_alerts_details.html
+++ b/crowdstrike_get_alerts_details.html
@@ -146,14 +146,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id }}' }], 0, {{ container.id }}, null, false);">{{ data.composite_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.composite_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/crowdstrike_get_detections_details.html
+++ b/crowdstrike_get_detections_details.html
@@ -146,14 +146,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id }}' }], 0, {{ container.id }}, null, false);">{{ data.detection_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.detection_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/crowdstrike_get_device_scroll.html
+++ b/crowdstrike_get_device_scroll.html
@@ -164,7 +164,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ resource }}' }], 0, {{ container.id }}, null, false);">{{ resource }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ resource|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ resource }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/crowdstrike_get_indicator.html
+++ b/crowdstrike_get_indicator.html
@@ -130,7 +130,7 @@
                         <td>
                           {% if resource.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -142,7 +142,7 @@
                         <td>
                           {% if resource.type %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator type'], 'value': '{{ resource.type }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator type'], 'value': '{{ resource.type|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.type }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -154,7 +154,7 @@
                         <td>
                           {% if resource.value %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': [ 'domain', 'ip', 'ipv6', 'sha256', 'md5' ], 'value': '{{ resource.value }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': [ 'domain', 'ip', 'ipv6', 'sha256', 'md5' ], 'value': '{{ resource.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.value }}
                               &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -165,7 +165,7 @@
                         <td>
                           {% if resource.action %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ resource.action }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ resource.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.action }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -180,7 +180,7 @@
                         <td>
                           {% if resource.severity %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ resource.severity }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ resource.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.severity }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -195,7 +195,7 @@
                               {% for platform in resource.platforms %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike indicator platforms'], 'value': '{{ platform }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike indicator platforms'], 'value': '{{ platform|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ platform }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_get_user_roles.html
+++ b/crowdstrike_get_user_roles.html
@@ -132,7 +132,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike user role id'], 'value': '{{ item.role_name }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike user role id'], 'value': '{{ item.role_name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item.role_name }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_get_zta_data.html
+++ b/crowdstrike_get_zta_data.html
@@ -123,7 +123,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ item.aid }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ item.aid|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item.aid }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -131,7 +131,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ item.cid }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ item.cid|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item.cid }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_hunt_view.html
+++ b/crowdstrike_hunt_view.html
@@ -120,7 +120,7 @@
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type }}' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type|escapejs }}' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.ioc }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -162,7 +162,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ curr_entry.device_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ curr_entry.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ curr_entry.device_id }}
                               &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/crowdstrike_list_custom_indicators.html
+++ b/crowdstrike_list_custom_indicators.html
@@ -183,7 +183,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['md5'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['md5'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -195,7 +195,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -207,7 +207,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -249,7 +249,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -261,7 +261,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -273,7 +273,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -315,7 +315,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -327,7 +327,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -339,7 +339,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -381,7 +381,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -393,7 +393,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -405,7 +405,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -447,7 +447,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -459,7 +459,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -471,7 +471,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_list_detections.html
+++ b/crowdstrike_list_detections.html
@@ -142,14 +142,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id }}' }], 0, {{ container.id }}, null, false);">{{ data.detection_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.detection_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/crowdstrike_list_epp_alerts.html
+++ b/crowdstrike_list_epp_alerts.html
@@ -142,14 +142,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id }}' }], 0, {{ container.id }}, null, false);">{{ data.composite_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.composite_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/crowdstrike_list_incident_behaviors.html
+++ b/crowdstrike_list_incident_behaviors.html
@@ -163,7 +163,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike incidentbehavior id'], 'value': '{{ item }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike incidentbehavior id'], 'value': '{{ item|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_list_incidents.html
+++ b/crowdstrike_list_incidents.html
@@ -163,7 +163,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike incident id'], 'value': '{{ item }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike incident id'], 'value': '{{ item|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_list_ioa_rule_groups.html
+++ b/crowdstrike_list_ioa_rule_groups.html
@@ -127,7 +127,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -163,7 +163,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ rule.instance_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_list_users.html
+++ b/crowdstrike_list_users.html
@@ -146,21 +146,21 @@
                           <td>{{ resource.last_name }}</td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike user id'], 'value': '{{ resource.uid }}' }], 0, {{ container.id }}, null, false);">{{ resource.uid }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike user id'], 'value': '{{ resource.uid|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ resource.uid }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike unique user id'], 'value': '{{ resource.uuid }}' }], 0, {{ container.id }}, null, false);">{{ resource.uuid }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike unique user id'], 'value': '{{ resource.uuid|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ resource.uuid }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ resource.cid }}' }], 0, {{ container.id }}, null, false);">{{ resource.cid }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ resource.cid|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ resource.cid }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/crowdstrike_process_list_view.html
+++ b/crowdstrike_process_list_view.html
@@ -125,7 +125,7 @@
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ result.param.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ result.param.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.id }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -137,7 +137,7 @@
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type }}' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type|escapejs }}' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.ioc }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -178,7 +178,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': [ 'falcon process id' ], 'value': '{{ curr_entry.falcon_process_id }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': [ 'falcon process id' ], 'value': '{{ curr_entry.falcon_process_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.falcon_process_id }}
                             &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/crowdstrike_remove_hosts.html
+++ b/crowdstrike_remove_hosts.html
@@ -107,7 +107,7 @@
             <td>Host Group ID</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ result.param.host_group_id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ result.param.host_group_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.host_group_id }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -119,7 +119,7 @@
               <td>Hostname</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['host name'], 'value': '{{ result.param.hostname }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['host name'], 'value': '{{ result.param.hostname|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.hostname }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -132,7 +132,7 @@
               <td>Device ID</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ result.param.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.device_id }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -163,7 +163,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ group.id }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ group.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ group.id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_set_status_view.html
+++ b/crowdstrike_set_status_view.html
@@ -97,7 +97,7 @@ a:hover {
           <tr>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': [ 'falcon detection id' ], 'value': '{{ result.param.id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': [ 'falcon detection id' ], 'value': '{{ result.param.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.id }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>

--- a/crowdstrike_update_indicator.html
+++ b/crowdstrike_update_indicator.html
@@ -99,14 +99,14 @@ a:hover {
           <tr>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type }}' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type|escapejs }}' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.ioc }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator action' ], 'value': '{{ result.param.action }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator action' ], 'value': '{{ result.param.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.action }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>

--- a/crowdstrike_update_ioa_rule.html
+++ b/crowdstrike_update_ioa_rule.html
@@ -126,7 +126,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -174,7 +174,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ rule.instance_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_update_ioa_rule_group.html
+++ b/crowdstrike_update_ioa_rule_group.html
@@ -126,7 +126,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -174,7 +174,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ rule.instance_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -219,7 +219,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ resource.id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -227,7 +227,7 @@
                             </td>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ policy_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -263,7 +263,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ resource.id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -271,7 +271,7 @@
                             </td>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ policy_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrike_url_reputation.html
+++ b/crowdstrike_url_reputation.html
@@ -119,7 +119,7 @@
                 <td>URL</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.url }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -188,7 +188,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -222,7 +222,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -234,7 +234,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -246,7 +246,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -258,7 +258,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -270,7 +270,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -282,7 +282,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -294,7 +294,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -306,7 +306,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -321,7 +321,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -339,7 +339,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -359,7 +359,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -380,7 +380,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/crowdstrikeoauthapi.json
+++ b/crowdstrikeoauthapi.json
@@ -139,7 +139,7 @@
             "description": "Run a query against CrowdStrike API",
             "type": "investigate",
             "identifier": "run_query",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "endpoint": {
                     "data_type": "string",

--- a/crowdstrikeoauthapi.json
+++ b/crowdstrikeoauthapi.json
@@ -2442,7 +2442,7 @@
             "verbose": "This action supports filtering in order to retrieve a particular set of detections.",
             "type": "investigate",
             "identifier": "list_detections",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "limit": {
                     "data_type": "numeric",
@@ -3255,7 +3255,7 @@
             "description": "Get a list of epp alerts, replaces legacy Detects API",
             "type": "investigate",
             "identifier": "list_epp_alerts",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "limit": {
                     "data_type": "numeric",
@@ -6655,7 +6655,7 @@
             "verbose": "This action supports filtering in order to retrieve a particular set of alerts.",
             "type": "investigate",
             "identifier": "list_alerts",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "limit": {
                     "data_type": "numeric",
@@ -7000,7 +7000,7 @@
             "verbose": "This action supports filtering in order to retrieve a particular session.",
             "type": "investigate",
             "identifier": "list_sessions",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "limit": {
                     "data_type": "numeric",
@@ -7716,7 +7716,7 @@
             "description": "Retrieve results of an active responder command executed on a single host",
             "type": "investigate",
             "identifier": "get_command_details",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "cloud_request_id": {
                     "data_type": "string",
@@ -7875,7 +7875,7 @@
             "description": "Get a list of files for the specified RTR session",
             "type": "investigate",
             "identifier": "list_session_files",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "session_id": {
                     "data_type": "string",
@@ -9990,7 +9990,7 @@
             "verbose": "This action fetches incidents using pagination logic.",
             "type": "investigate",
             "identifier": "list_incidents",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "filter": {
                     "data_type": "string",
@@ -12567,7 +12567,7 @@
             "description": "Queries for custom indicators in your customer account",
             "type": "investigate",
             "identifier": "list_custom_indicators",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "indicator_value": {
                     "data_type": "string",
@@ -21300,7 +21300,7 @@
             "description": "List IOA Rule Groups",
             "type": "investigate",
             "identifier": "list_ioa_rule_groups",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "fql_query": {
                     "data_type": "string",

--- a/crowdstrikeoauthapi.json
+++ b/crowdstrikeoauthapi.json
@@ -20808,10 +20808,9 @@
                 },
                 "enabled": {
                     "data_type": "boolean",
-                    "description": "Enable or disable the Rule Group",
+                    "description": "Enable or disable the Rule Group (omit to leave unchanged)",
                     "required": false,
-                    "order": 4,
-                    "default": false
+                    "order": 4
                 },
                 "comment": {
                     "data_type": "string",
@@ -22310,9 +22309,8 @@
                 },
                 "enabled": {
                     "data_type": "boolean",
-                    "description": "Enable this rule",
+                    "description": "Enable this rule (omit to leave unchanged)",
                     "required": false,
-                    "default": false,
                     "order": 10
                 }
             },

--- a/crowdstrikeoauthapi.json
+++ b/crowdstrikeoauthapi.json
@@ -17645,13 +17645,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.document_password",
-                    "data_type": "password",
-                    "example_values": [
-                        "test_password"
-                    ]
-                },
-                {
                     "data_path": "action_result.parameter.enable_tor",
                     "data_type": "boolean",
                     "example_values": [
@@ -18757,6 +18750,10 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.document_password",
+                    "data_type": "password"
                 }
             ],
             "versions": "EQ(*)",
@@ -18893,13 +18890,6 @@
                     "example_values": [
                         true,
                         false
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.document_password",
-                    "data_type": "password",
-                    "example_values": [
-                        "test_password"
                     ]
                 },
                 {
@@ -19892,6 +19882,10 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.document_password",
+                    "data_type": "password"
                 }
             ],
             "versions": "EQ(*)",

--- a/crowdstrikeoauthapi.json
+++ b/crowdstrikeoauthapi.json
@@ -116,15 +116,10 @@
             "default": 50,
             "description": "Maximum allowed continuous blank lines"
         },
-        "preprocess_script": {
-            "data_type": "file",
-            "description": "Script with functions to preprocess containers and artifacts",
-            "order": 14
-        },
         "detonate_timeout": {
             "data_type": "numeric",
             "description": "Timeout for detonation result in minutes (Default: 15 minutes)",
-            "order": 15,
+            "order": 14,
             "default": 15
         }
     },

--- a/crowdstrikeoauthapi.json
+++ b/crowdstrikeoauthapi.json
@@ -14323,6 +14323,20 @@
                     ]
                 },
                 {
+                    "data_path": "action_result.summary.total_process_count",
+                    "data_type": "numeric",
+                    "example_values": [
+                        250
+                    ]
+                },
+                {
+                    "data_path": "action_result.summary.truncated",
+                    "data_type": "boolean",
+                    "example_values": [
+                        true
+                    ]
+                },
+                {
                     "data_path": "action_result.message",
                     "data_type": "string",
                     "example_values": [

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -308,6 +308,8 @@ class CrowdstrikeConnector(BaseConnector):
     def _save_results(self, results, param, is_incident=False):
         reused_containers = 0
         containers_processed = 0
+        failed_offsets = []
+        save_failures = 0
         artifact_type = "incident" if is_incident else "event"
 
         for i, result in enumerate(results):
@@ -315,16 +317,19 @@ class CrowdstrikeConnector(BaseConnector):
             # result is a dictionary of a single container and artifacts
             if "container" not in result:
                 self.debug_print(f"Skipping empty container # {i}")
+                save_failures += 1
                 continue
 
             if "artifacts" not in result:
                 # ignore containers without artifacts
                 self.debug_print(f"Skipping container # {i} without artifacts")
+                save_failures += 1
                 continue
 
             if len(result["artifacts"]) == 0:
                 # ignore containers without artifacts
                 self.debug_print(f"Skipping container # {i} with 0 artifacts")
+                save_failures += 1
                 continue
 
             config = self.get_config()
@@ -348,6 +353,8 @@ class CrowdstrikeConnector(BaseConnector):
 
                 if phantom.is_fail(ret_val):
                     self.debug_print("Error occurred while creating a new container")
+                    failed_offsets.extend(self._get_artifact_offsets(artifacts))
+                    save_failures += 1
                     continue
             else:
                 reused_containers += 1
@@ -368,13 +375,19 @@ class CrowdstrikeConnector(BaseConnector):
 
             if phantom.is_fail(ret_val):
                 self.debug_print(f"Error occurred while adding {len_artifacts} artifacts to container: {container_id}")
+                failed_offsets.extend(self._get_artifact_offsets(artifacts))
+                save_failures += 1
 
             containers_processed += 1
 
         if reused_containers and config.get("collate"):
             self.save_progress("Some containers were re-used due to collate set to True")
 
-        return containers_processed
+        return containers_processed, failed_offsets, save_failures
+
+    @staticmethod
+    def _get_artifact_offsets(artifacts):
+        return [artifact.get("source_data_identifier") for artifact in artifacts if isinstance(artifact.get("source_data_identifier"), int)]
 
     @staticmethod
     def validate_comma_seperated_values(values):
@@ -3395,7 +3408,9 @@ class CrowdstrikeConnector(BaseConnector):
                             return action_result.get_status()
                     elif max_crlf is None:
                         # Save events after refreshing the token
-                        self._save_events_on_poll(config, total_blank_lines_count, param)
+                        ret_val = self._save_events_on_poll(config, total_blank_lines_count, param, action_result)
+                        if phantom.is_fail(ret_val):
+                            return action_result.get_status()
 
                 if stream_data is None:
                     # Done with all the event data for now
@@ -3455,7 +3470,9 @@ class CrowdstrikeConnector(BaseConnector):
                     phantom.APP_ERROR, f"{CROWDSTRIKE_EVENTS_FETCH_ERROR}. Error response from server: {err_message}"
                 )
 
-        self._save_events_on_poll(config, total_blank_lines_count, param)
+        ret_val = self._save_events_on_poll(config, total_blank_lines_count, param, action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
 
         if is_error_occurred:
             if restart_process:
@@ -3466,7 +3483,7 @@ class CrowdstrikeConnector(BaseConnector):
 
         return action_result.set_status(phantom.APP_SUCCESS)
 
-    def _save_events_on_poll(self, config, total_blank_lines_count, param):
+    def _save_events_on_poll(self, config, total_blank_lines_count, param, action_result):
         # Check if to collate the data or not
         collate = config.get("collate", True)
 
@@ -3478,6 +3495,8 @@ class CrowdstrikeConnector(BaseConnector):
         self.save_progress(CROWDSTRIKE_GOT_EVENTS_MESSAGE.format(len(self._events)))
 
         if self._events:
+            failed_offsets = []
+            save_failures = 0
             # Update messages to reference both event types
             self.send_progress("Parsing the fetched Detection Events...")
             results = events_parser.parse_events(self._events, self, collate)
@@ -3486,15 +3505,27 @@ class CrowdstrikeConnector(BaseConnector):
                 self.save_progress(
                     "Adding {} event artifact{}. Empty containers will be skipped.".format(len(results), "s" if len(results) > 1 else "")
                 )
-                self._save_results(results, param)
-                self.send_progress("Events have been stored")
+                _, failed_offsets, save_failures = self._save_results(results, param)
+                self.send_progress("Event save processing completed")
             if not self.is_poll_now():
                 last_event = self._events[-1]
                 last_offset_id = last_event["metadata"]["offset"]
-                self._state["last_offset_id"] = last_offset_id + 1
+                next_offset_id = last_offset_id + 1
+                if failed_offsets:
+                    next_offset_id = min(next_offset_id, min(failed_offsets))
+                if not save_failures or failed_offsets:
+                    self._state["last_offset_id"] = next_offset_id
                 self.save_state(self._state)
 
             self._events = []
+
+            if save_failures:
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Failed to save {save_failures} detection result(s); the next poll will retry them",
+                )
+
+        return phantom.APP_SUCCESS
 
     def _poll_incidents(self, action_result, param, max_incidents):
         self.save_progress("Starting incident ingestion...")
@@ -3532,15 +3563,29 @@ class CrowdstrikeConnector(BaseConnector):
             incidents = response.get("resources", [])
 
             if incidents:
-                # Update timestamp for next poll if not poll_now
-                if not self.is_poll_now():
-                    latest_timestamp = max(incident.get("modified_timestamp", 0) for incident in incidents)
-                    self._state["last_incident_timestamp"] = latest_timestamp
-
-                # Process incidents through parser
+                incidents.sort(key=lambda incident: str(incident.get("modified_timestamp", "")))
                 self.save_progress(f"Processing {len(incidents)} incidents...")
-                incident_results = incidents_parser.process_incidents(incidents)
-                self._save_results(incident_results, param, True)
+                failed_incidents = 0
+                for incident in incidents:
+                    try:
+                        incident_results = incidents_parser.process_incidents([incident])
+                        if not incident_results:
+                            raise ValueError("Incident parser returned no result")
+                        _, _, save_failures = self._save_results(incident_results, param, True)
+                        failed_incidents += int(save_failures > 0)
+                    except Exception as e:
+                        failed_incidents += 1
+                        self.debug_print(f"Failed to ingest incident {incident.get('incident_id')}: {self._get_error_message_from_exception(e)}")
+
+                if failed_incidents:
+                    return action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"Failed to ingest {failed_incidents} of {len(incidents)} incidents; the next poll will retry the batch",
+                    )
+
+                if not self.is_poll_now():
+                    latest_timestamp = max(incident.get("modified_timestamp", "") for incident in incidents)
+                    self._state["last_incident_timestamp"] = latest_timestamp
                 self.save_progress("Successfully processed incidents")
             else:
                 self.save_progress("No incidents found in response")

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -185,18 +185,19 @@ class CrowdstrikeConnector(BaseConnector):
         gt_date = datetime.utcnow() - timedelta(seconds=int(time_interval))
         # Cutoff Timestamp From String
         common_str = " ".join(container["name"].split()[:-1])
-        request_str = CROWDSTRIKE_FILTER_REQUEST_STR.format(
-            self.get_phantom_base_url(),
-            self.get_asset_id(),
-            common_str,
-            gt_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        )
+        request_url = f"{self.get_phantom_base_url()}rest/container"
+        request_params = {
+            "page_size": 0,
+            "_filter_asset": self.get_asset_id(),
+            "_filter_name__contains": f'"{common_str}"',
+            "_filter_start_time__gte": f'"{gt_date.strftime("%Y-%m-%dT%H:%M:%SZ")}"',
+        }
 
         try:
-            r = requests.get(request_str, verify=False)  # nosemgrep
+            r = requests.get(request_url, params=request_params, verify=False)  # nosemgrep
         except Exception as e:
             self.debug_print(f"Error making local rest call: {self._get_error_message_from_exception(e)}")
-            self.debug_print(f"DB QUERY: {request_str}")
+            self.debug_print(f"DB QUERY: {request_url}")
             return phantom.APP_ERROR, None
 
         try:
@@ -211,6 +212,8 @@ class CrowdstrikeConnector(BaseConnector):
                 most_recent = gt_date
                 most_recent_id = None
                 for container in resp_json["data"]:
+                    if str(container.get("asset")) != str(self.get_asset_id()):
+                        continue
                     if container.get("parent_container"):
                         # container created through aggregation, skip this
                         continue

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -99,10 +99,6 @@ class CrowdstrikeConnector(BaseConnector):
 
         self._oauth_access_token = self.decrypt_state()
 
-        ret = self._handle_preprocess_scripts()
-        if phantom.is_fail(ret):
-            return ret
-
         return phantom.APP_SUCCESS
 
     def finalize(self):
@@ -153,34 +149,6 @@ class CrowdstrikeConnector(BaseConnector):
         except Exception:
             return False
         return True
-
-    def _handle_preprocess_scripts(self):
-        config = self.get_config()
-        script = config.get("preprocess_script")
-
-        self._preprocess_container = lambda x: x
-
-        if script:
-            try:  # Try to laod in script to preprocess artifacts
-                import importlib.util
-
-                preprocess_methods = importlib.util.spec_from_loader("preprocess_methods", loader=None)
-                self._script_module = importlib.util.module_from_spec(preprocess_methods)
-                exec(script, self._script_module.__dict__)
-            except Exception as e:
-                self.save_progress(f"Error loading custom script. Error: {self._get_error_message_from_exception(e)}")
-                return phantom.APP_ERROR
-
-            try:
-                self._preprocess_container = self._script_module.preprocess_container
-            except Exception as ex:
-                self.save_progress(
-                    "Error loading custom script. Does not contain preprocess_container function, "
-                    f"Error:{self._get_error_message_from_exception(ex)}"
-                )
-                return phantom.APP_ERROR
-
-        return phantom.APP_SUCCESS
 
     def _get_error_message_from_exception(self, e):
         """This method is used to get appropriate error message from the exception.
@@ -365,12 +333,6 @@ class CrowdstrikeConnector(BaseConnector):
 
             container = result["container"]
             container["artifacts"] = artifacts
-
-            if hasattr(self, "_preprocess_container"):
-                try:
-                    container = self._preprocess_container(container)
-                except Exception as e:
-                    self.debug_print(f"Preprocess error: {self._get_error_message_from_exception(e)}")
 
             artifacts = container.pop("artifacts", [])
 

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -1760,18 +1760,42 @@ class CrowdstrikeConnector(BaseConnector):
             filter = f"{filter}{key}: '{item}', "  # or opeartion with given hostname/s
         filter = filter[:-2]  # removing last trailing , and space
 
-        check_list_items = self._get_ids_with_subtenants(
+        resolved_items = self._get_ids_with_subtenants(
             action_result, CROWDSTRIKE_GET_DEVICE_ID_ENDPOINT, param={"filter": filter}, subtenant=subtenant
         )
 
-        if check_list_items is None:
+        if resolved_items is None:
             return action_result.get_status(), flag, []
 
-        if len(list_items) != len(check_list_items):
-            flag = True
-            check_list_items = []
+        if isinstance(resolved_items, dict):
+            id_tenant_map = resolved_items
+        else:
+            id_tenant_map = dict.fromkeys(resolved_items, subtenant)
 
-        return phantom.APP_SUCCESS, flag, check_list_items
+        if len(list_items) != len(id_tenant_map):
+            flag = True
+            return phantom.APP_SUCCESS, flag, []
+
+        requested_items = {str(item).lower() for item in list_items}
+        tenant_ids = defaultdict(list)
+        for device_id, tenant in id_tenant_map.items():
+            tenant_ids[tenant].append(device_id)
+
+        for tenant, device_ids in tenant_ids.items():
+            details = self._get_details(
+                action_result,
+                CROWDSTRIKE_GET_DEVICE_DETAILS_ENDPOINT,
+                {"ids": device_ids},
+                method="post",
+                subtenant=tenant,
+            )
+            if details is None:
+                return action_result.get_status(), flag, []
+            if len(details) != len(device_ids) or any(str(device.get(key, "")).lower() not in requested_items for device in details):
+                flag = True
+                return phantom.APP_SUCCESS, flag, []
+
+        return phantom.APP_SUCCESS, flag, list(id_tenant_map)
 
     def _perform_device_action(self, action_result, param):
         count = 0

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -2938,6 +2938,7 @@ class CrowdstrikeConnector(BaseConnector):
         # 5 second wait per request
         timeout_segment_length = 5
         timeout_segments = timeout / timeout_segment_length
+        deadline = time.monotonic() + timeout
 
         count = 0
         while count < int(timeout_segments):
@@ -2954,7 +2955,15 @@ class CrowdstrikeConnector(BaseConnector):
             if resources and len(resources):
                 # if complete, grab all sequences
                 if resources[0].get("complete", False):
+                    max_sequences = 10000
                     while True:
+                        if time.monotonic() >= deadline:
+                            return action_result.set_status(phantom.APP_ERROR, "Timed out while fetching command result sequences")
+                        if sequence_id >= max_sequences:
+                            return action_result.set_status(
+                                phantom.APP_ERROR,
+                                f"Command results exceeded the {max_sequences}-sequence limit",
+                            )
                         self.save_progress(f"sequence: {sequence_id}")
                         params = {
                             "cloud_request_id": cloud_request_id,

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -3728,21 +3728,22 @@ class CrowdstrikeConnector(BaseConnector):
         except json.JSONDecodeError as e:
             return action_result.set_status(phantom.APP_ERROR, f"Failed to parse field_values: {e}")
 
+        rule_update = {
+            "instance_id": param["rule_id"],
+            "pattern_severity": param["severity"],
+            "name": param["name"],
+            "description": param["description"],
+            "disposition_id": param["disposition_id"],
+            "field_values": field_values,
+        }
+        if "enabled" in param:
+            rule_update["enabled"] = param["enabled"]
+
         update_params = {
             "rulegroup_id": param["rule_group_id"],
             "rulegroup_version": param["rule_group_version"],
             "instance_version": param["rule_version"],
-            "rule_updates": [
-                {
-                    "instance_id": param["rule_id"],
-                    "pattern_severity": param["severity"],
-                    "enabled": param.get("enabled", False),
-                    "name": param["name"],
-                    "description": param["description"],
-                    "disposition_id": param["disposition_id"],
-                    "field_values": field_values,
-                }
-            ],
+            "rule_updates": [rule_update],
         }
         update_comment = param.get("comment")
         if update_comment:
@@ -3790,9 +3791,10 @@ class CrowdstrikeConnector(BaseConnector):
             "rulegroup_version": param["version"],
             "name": param["name"],
             "description": param["description"],
-            "enabled": param.get("enabled", False),
             "comment": param["comment"],
         }
+        if "enabled" in param:
+            update_params["enabled"] = param["enabled"]
         ret_val, resp_json = self._make_rest_call_helper_oauth2(
             action_result,
             CROWDSTRIKE_IOA_CREATE_RULE_GROUP_ENDPOINT,

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -4284,7 +4284,9 @@ class CrowdstrikeConnector(BaseConnector):
     def _handle_detonate_url(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         # Add an action result to the App Run
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        result_param = dict(param)
+        result_param.pop("document_password", None)
+        action_result = self.add_action_result(ActionResult(result_param))
 
         url = param["url"]
         if "https://" in url:
@@ -4354,7 +4356,9 @@ class CrowdstrikeConnector(BaseConnector):
     def _handle_detonate_file(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         # Add an action result to the App Run
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        result_param = dict(param)
+        result_param.pop("document_password", None)
+        action_result = self.add_action_result(ActionResult(result_param))
         try:
             file_id = param["vault_id"]
             _, _, file_info = phantom_rules.vault_info(vault_id=file_id)

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -398,20 +398,23 @@ class CrowdstrikeConnector(BaseConnector):
 
         offset = param.get("offset", 0)
 
+        pages = 0
         while True:
+            pages += 1
+            if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
+                return None
             param.update({"offset": offset})
             ret_val, response = self._make_rest_call_helper_oauth2(action_result, endpoint, params=param)
 
             if phantom.is_fail(ret_val):
                 return None
 
+            resources = response.get("resources", [])
             prev_offset = offset
-            offset = response.get("meta", {}).get("pagination", {}).get("offset")
-            if offset == prev_offset:
-                offset += len(response.get("resources", []))
-
-            # Fetching total from the response
-            total = response.get("meta", {}).get("pagination", {}).get("total")
+            pagination = response.get("meta", {}).get("pagination", {})
+            offset = pagination.get("offset")
+            total = pagination.get("total")
 
             if len(response.get("errors", [])):
                 error = response.get("errors")[0]
@@ -426,8 +429,22 @@ class CrowdstrikeConnector(BaseConnector):
                 )
                 return None
 
-            if response.get("resources"):
-                list_ids.extend(response.get("resources"))
+            try:
+                offset = int(offset)
+                total = int(total)
+                prev_offset = int(prev_offset)
+            except (TypeError, ValueError):
+                action_result.set_status(phantom.APP_ERROR, "Pagination offset and total must be integers")
+                return None
+
+            if offset == prev_offset:
+                offset += len(resources)
+            if offset <= prev_offset and offset < total:
+                action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
+                return None
+
+            if resources:
+                list_ids.extend(resources)
 
             if limit and len(list_ids) >= int(limit):
                 return list_ids[: int(limit)]
@@ -466,8 +483,14 @@ class CrowdstrikeConnector(BaseConnector):
                 subtenants.extend(configured_subtenants)
 
         for subtenant in subtenants:
+            offset = ""
+            pages = 0
             subtenant_total_counted = False
             while True:
+                pages += 1
+                if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                    action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
+                    return None
                 params.update({"offset": offset})
                 params.update({"limit": 100})
 
@@ -479,7 +502,9 @@ class CrowdstrikeConnector(BaseConnector):
                         break
                     return None
 
-                offset = response.get("meta", {}).get("pagination", {}).get("offset")
+                previous_offset = offset
+                pagination = response.get("meta", {}).get("pagination", {})
+                offset = pagination.get("offset")
 
                 if len(response.get("errors", [])):
                     error = response.get("errors")[0]
@@ -502,9 +527,15 @@ class CrowdstrikeConnector(BaseConnector):
                 if limit and len(list_ids) >= limit:
                     return list_ids[:limit]
 
-                if (not offset) and (not response.get("meta", {}).get("pagination", {}).get("next_page")):
-                    # Continue (next subtenant if there is one)
-                    break
+                if not offset:
+                    if not pagination.get("next_page"):
+                        # Continue (next subtenant if there is one)
+                        break
+                    action_result.set_status(phantom.APP_ERROR, "Server pagination did not provide a continuation offset")
+                    return None
+                if offset == previous_offset:
+                    action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
+                    return None
 
         return list_ids
 
@@ -1520,7 +1551,11 @@ class CrowdstrikeConnector(BaseConnector):
 
         self.send_progress("Completed 0 %")
         ioc_infos = []
+        pages = 0
         while more:
+            pages += 1
+            if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                return action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
             ret_val, response = self._make_rest_call_helper_oauth2(
                 action_result,
                 CROWDSTRIKE_GET_COMBINED_CUSTOM_INDICATORS_ENDPOINT,
@@ -1543,6 +1578,8 @@ class CrowdstrikeConnector(BaseConnector):
             after = response.get("meta", {}).get("pagination", {}).get("after")
             if after is None:
                 break
+            if not response.get("resources") or after == api_data.get("after"):
+                return action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
             total = response.get("meta", {}).get("pagination", {}).get("total")
 
             if total:
@@ -2551,7 +2588,11 @@ class CrowdstrikeConnector(BaseConnector):
         total_rows = 0
         offset = -1
         results = []
+        pages = 0
         while offset < total_rows:
+            pages += 1
+            if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                return action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
             if offset >= 0:
                 params["offset"] = offset
 
@@ -2568,7 +2609,10 @@ class CrowdstrikeConnector(BaseConnector):
             results += resp_json["resources"]
 
             total_rows = resp_json["meta"]["pagination"]["total"]
+            previous_offset = offset
             offset = resp_json["meta"]["pagination"]["offset"]
+            if offset < total_rows and offset <= previous_offset:
+                return action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
 
         resp_json["resources"] = results
         action_result.add_data(resp_json)
@@ -2590,7 +2634,11 @@ class CrowdstrikeConnector(BaseConnector):
         total_rows = 0
         offset = -1
         results = []
+        pages = 0
         while offset < total_rows:
+            pages += 1
+            if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                return action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
             if offset >= 0:
                 params["offset"] = offset
 
@@ -2607,7 +2655,10 @@ class CrowdstrikeConnector(BaseConnector):
             results += resp_json["resources"]
 
             total_rows = resp_json["meta"]["pagination"]["total"]
+            previous_offset = offset
             offset = resp_json["meta"]["pagination"]["offset"]
+            if offset < total_rows and offset <= previous_offset:
+                return action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
 
         resp_json["resources"] = results
         action_result.add_data(resp_json)
@@ -2626,7 +2677,11 @@ class CrowdstrikeConnector(BaseConnector):
         total_rows = 0
         offset = -1
         results = []
+        pages = 0
         while offset < total_rows:
+            pages += 1
+            if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                return action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
             if offset >= 0:
                 params["offset"] = offset
 
@@ -2643,7 +2698,10 @@ class CrowdstrikeConnector(BaseConnector):
             results += resp_json["resources"]
 
             total_rows = resp_json["meta"]["pagination"]["total"]
+            previous_offset = offset
             offset = resp_json["meta"]["pagination"]["offset"]
+            if offset < total_rows and offset <= previous_offset:
+                return action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
 
         resp_json["resources"] = results
         action_result.add_data(resp_json)
@@ -2664,7 +2722,11 @@ class CrowdstrikeConnector(BaseConnector):
         total_rows = 0
         offset = -1
         results = []
+        pages = 0
         while offset < total_rows:
+            pages += 1
+            if pages > CROWDSTRIKE_MAX_PAGINATION_PAGES:
+                return action_result.set_status(phantom.APP_ERROR, "Exceeded maximum pagination rounds")
             if offset >= 0:
                 params["offset"] = offset
 
@@ -2697,7 +2759,10 @@ class CrowdstrikeConnector(BaseConnector):
                 results += next_resp_json["resources"]
 
             total_rows = resp_json["meta"]["pagination"]["total"]
+            previous_offset = offset
             offset = resp_json["meta"]["pagination"]["offset"]
+            if offset < total_rows and offset <= previous_offset:
+                return action_result.set_status(phantom.APP_ERROR, "Server pagination did not advance")
 
         resp_json["resources"] = results
         total_rows = len(results)

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -4945,9 +4945,12 @@ class CrowdstrikeConnector(BaseConnector):
         # store the r_text in debug data, it will get dumped in the logs if the action fails
         if hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": response.status_code})
-            if not self._stream_file_data:
-                action_result.add_debug_data({"r_text": response.text})
-            action_result.add_debug_data({"r_headers": response.headers})
+            if CROWDSTRIKE_OAUTH_TOKEN_ENDPOINT in getattr(response, "url", ""):
+                action_result.add_debug_data({"r_text": "<token endpoint response redacted>"})
+            else:
+                if not self._stream_file_data:
+                    action_result.add_debug_data({"r_text": response.text})
+                action_result.add_debug_data({"r_headers": response.headers})
 
         # Reset_password returns empty body
         if not self._stream_file_data and not response.text and 200 <= response.status_code < 399:

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -4591,7 +4591,7 @@ class CrowdstrikeConnector(BaseConnector):
             )
 
         return action_result.set_status(
-            phantom.APP_SUCCESS,
+            phantom.APP_ERROR,
             f"Timed out while waiting for the result. To know the status of submitted \
             sample please run the check status action with {resource_id} resource id.",
         )

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -1855,6 +1855,12 @@ class CrowdstrikeConnector(BaseConnector):
                 if phantom.is_fail(ret_val):
                     return action_result.get_status()
 
+                if response.get("errors"):
+                    error_msg = ", ".join(
+                        f"{error.get('code', 'Unknown')}: {error.get('message', 'Unknown error')}" for error in response["errors"]
+                    )
+                    return action_result.set_status(phantom.APP_ERROR, f"Device action failed: {error_msg}")
+
                 if not response.get("resources"):
                     return action_result.set_status(
                         phantom.APP_ERROR,
@@ -1899,6 +1905,12 @@ class CrowdstrikeConnector(BaseConnector):
 
                 if phantom.is_fail(ret_val):
                     return action_result.get_status()
+
+                if response.get("errors"):
+                    error_msg = ", ".join(
+                        f"{error.get('code', 'Unknown')}: {error.get('message', 'Unknown error')}" for error in response["errors"]
+                    )
+                    return action_result.set_status(phantom.APP_ERROR, f"Device action failed: {error_msg}")
 
                 del list_ids[: min(100, len(list_ids))]
 
@@ -3747,6 +3759,10 @@ class CrowdstrikeConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
+        if response.get("errors"):
+            error_msg = ", ".join(f"{error.get('code', 'Unknown')}: {error.get('message', 'Unknown error')}" for error in response["errors"])
+            return action_result.set_status(phantom.APP_ERROR, f"Indicator upload failed: {error_msg}")
+
         for indicator_data in response.get("resources", []):
             action_result.add_data(indicator_data)
 
@@ -4774,8 +4790,8 @@ class CrowdstrikeConnector(BaseConnector):
                         else:
                             return RetVal(
                                 action_result.set_status(
-                                    phantom.APP_SUCCESS,
-                                    "Error from server. Error details: {}".format(error_msg.strip(", ")),
+                                    phantom.APP_ERROR,
+                                    "Partial failure reported by server. Error details: {}".format(error_msg.strip(", ")),
                                 ),
                                 resp_json,
                             )

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -17,6 +17,7 @@
 import ipaddress
 import json
 import os
+import re
 import time
 import traceback
 import uuid
@@ -525,8 +526,7 @@ class CrowdstrikeConnector(BaseConnector):
         if not endpoint:
             return action_result.set_status(phantom.APP_ERROR, "Please provide endpoint path")
 
-        # Ensure using query endpoint
-        if "/queries/" not in endpoint.lower():
+        if not re.fullmatch(r"/[A-Za-z0-9_-]+/queries/[A-Za-z0-9_-]+/v\d+", endpoint):
             return action_result.set_status(phantom.APP_ERROR, CROWDSTRIKE_INVALID_QUERY_ENDPOINT_MESSAGE_ERROR)
 
         params = {"limit": param.get("limit", 50), "offset": param.get("offset", 0)}

--- a/crowdstrikeoauthapi_connector.py
+++ b/crowdstrikeoauthapi_connector.py
@@ -442,6 +442,7 @@ class CrowdstrikeConnector(BaseConnector):
 
     def _hunt_paginator(self, action_result, endpoint, params, search_subtenants=False, subtenant=None):
         list_ids = list()
+        self._hunt_total = 0
 
         offset = ""
         limit = None
@@ -465,6 +466,7 @@ class CrowdstrikeConnector(BaseConnector):
                 subtenants.extend(configured_subtenants)
 
         for subtenant in subtenants:
+            subtenant_total_counted = False
             while True:
                 params.update({"offset": offset})
                 params.update({"limit": 100})
@@ -486,6 +488,13 @@ class CrowdstrikeConnector(BaseConnector):
                         "Error occurred in results:\r\nCode: {}\r\nMessage: {}".format(error.get("code"), error.get("message")),
                     )
                     return None
+
+                if not subtenant_total_counted:
+                    try:
+                        self._hunt_total += int(response.get("meta", {}).get("pagination", {}).get("total") or 0)
+                    except (TypeError, ValueError):
+                        pass
+                    subtenant_total_counted = True
 
                 if response.get("resources"):
                     list_ids.extend(response.get("resources"))
@@ -3510,7 +3519,14 @@ class CrowdstrikeConnector(BaseConnector):
         for process_id in response:
             action_result.add_data({"falcon_process_id": process_id})
 
-        action_result.set_summary({"process_count": len(response)})
+        total_process_count = max(self._hunt_total, len(response))
+        action_result.set_summary(
+            {
+                "process_count": len(response),
+                "total_process_count": total_process_count,
+                "truncated": total_process_count > len(response),
+            }
+        )
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/crowdstrikeoauthapi_consts.py
+++ b/crowdstrikeoauthapi_consts.py
@@ -148,6 +148,7 @@ CROWDSTRIKE_OAUTH_TOKEN_ENDPOINT = "/oauth2/token"
 CROWDSTRIKE_GET_DEVICE_ID_ENDPOINT = "/devices/queries/devices/v1"
 CROWDSTRIKE_GET_DEVICE_DETAILS_ENDPOINT = "/devices/entities/devices/v2"
 CROWDSTRIKE_GET_DEVICE_SCROLL_ENDPOINT = "/devices/queries/devices-scroll/v1"
+CROWDSTRIKE_MAX_PAGINATION_PAGES = 1000
 CROWDSTRIKE_GET_HOST_GROUP_ID_ENDPOINT = "/devices/queries/host-groups/v1"
 CROWDSTRIKE_GET_HOST_GROUP_DETAILS_ENDPOINT = "/devices/entities/host-groups/v1"
 CROWDSTRIKE_DEVICE_ACTION_ENDPOINT = "/devices/entities/devices-actions/v2"

--- a/crowdstrikeoauthapi_consts.py
+++ b/crowdstrikeoauthapi_consts.py
@@ -132,7 +132,6 @@ CROWDSTRIKE_RECEIVED_CR_LF_MESSAGE = "CR/LF received on iteration {} - continuin
 CROWDSTRIKE_BLANK_LINES_COUNT_MESSAGE = "Total blank lines count: {}"
 CROWDSTRIKE_GOT_EVENTS_MESSAGE = "Got {0} detection events"
 
-CROWDSTRIKE_FILTER_REQUEST_STR = '{0}rest/container?page_size=0&_filter_asset={1}&_filter_name__contains="{2}"&_filter_start_time__gte="{3}"'
 CROWDSTRIKE_FILTER_GET_IOC = "type:'{}'+value:'{}'"
 CROWDSTRIKE_FILTER_GET_CUSTOM_IOC = "(type:'{}' + value:'{}') + (deleted:'true', deleted: 'false')"
 CROWDSTRIKE_FILTER_GET_CUSTOM_IOC_RESOURCE_ID = "id:'{}' + (deleted:'true', deleted: 'false')"

--- a/parse_cs_incidents.py
+++ b/parse_cs_incidents.py
@@ -111,8 +111,8 @@ def process_incidents(incidents):
         container.update(_container_common)
 
         container["name"] = "{} on {} at {}".format(
-            incident.get("name", "Unnamed Incident"),
-            incident.get("hosts", [{}])[0].get("hostname", "Unknown Host"),
+            incident.get("name") or "Unnamed Incident",
+            (incident.get("hosts") or [{}])[0].get("hostname", "Unknown Host"),
             incident.get("start", "Unknown Time"),
         )
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Restricted the run query action to bare CrowdStrike query endpoint paths and corrected its read-only declaration.
 * Corrected read-only declarations for tenant-wide detection, incident, RTR, IOA, and indicator retrieval actions.
 * Encoded ingestion container lookups and limited container reuse to the current asset.
+* Reported the authoritative process total and whether list process results were truncated by the requested limit.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -14,3 +14,4 @@
 * Bounded RTR command result sequence retrieval by the action timeout and a hard sequence limit.
 * Redacted OAuth token endpoint bodies and headers from connector debug data.
 * Verified resolved device identities exactly match requested hostnames or device IDs before device actions run.
+* Reported device, indicator upload, and mixed API response errors as action failures.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Escaped connector widget values before embedding them in inline JavaScript handlers.
 * Restricted the run query action to bare CrowdStrike query endpoint paths and corrected its read-only declaration.
 * Corrected read-only declarations for tenant-wide detection, incident, RTR, IOA, and indicator retrieval actions.
+* Encoded ingestion container lookups and limited container reuse to the current asset.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Removed executable asset preprocessing so asset configuration cannot run connector code.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Removed executable asset preprocessing so asset configuration cannot run connector code.
 * Escaped connector widget values before embedding them in inline JavaScript handlers.
+* Restricted the run query action to bare CrowdStrike query endpoint paths and corrected its read-only declaration.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -11,3 +11,4 @@
 * Reported sandbox detonation poll timeouts as action failures while retaining follow-up data.
 * Protected detonation document passwords from action result parameter persistence.
 * Preserved existing IOA rule and rule-group enabled state when update actions omit the optional enabled parameter.
+* Bounded RTR command result sequence retrieval by the action timeout and a hard sequence limit.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Corrected read-only declarations for tenant-wide detection, incident, RTR, IOA, and indicator retrieval actions.
 * Encoded ingestion container lookups and limited container reuse to the current asset.
 * Reported the authoritative process total and whether list process results were truncated by the requested limit.
+* Bounded shared, custom-indicator, and IOA pagination loops and rejected non-advancing server cursors.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -10,3 +10,4 @@
 * Preserved detection and incident polling checkpoints when fetched records fail to persist in SOAR.
 * Reported sandbox detonation poll timeouts as action failures while retaining follow-up data.
 * Protected detonation document passwords from action result parameter persistence.
+* Preserved existing IOA rule and rule-group enabled state when update actions omit the optional enabled parameter.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -12,3 +12,4 @@
 * Protected detonation document passwords from action result parameter persistence.
 * Preserved existing IOA rule and rule-group enabled state when update actions omit the optional enabled parameter.
 * Bounded RTR command result sequence retrieval by the action timeout and a hard sequence limit.
+* Redacted OAuth token endpoint bodies and headers from connector debug data.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -13,3 +13,4 @@
 * Preserved existing IOA rule and rule-group enabled state when update actions omit the optional enabled parameter.
 * Bounded RTR command result sequence retrieval by the action timeout and a hard sequence limit.
 * Redacted OAuth token endpoint bodies and headers from connector debug data.
+* Verified resolved device identities exactly match requested hostnames or device IDs before device actions run.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Removed executable asset preprocessing so asset configuration cannot run connector code.
 * Escaped connector widget values before embedding them in inline JavaScript handlers.
 * Restricted the run query action to bare CrowdStrike query endpoint paths and corrected its read-only declaration.
+* Corrected read-only declarations for tenant-wide detection, incident, RTR, IOA, and indicator retrieval actions.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,3 +7,4 @@
 * Encoded ingestion container lookups and limited container reuse to the current asset.
 * Reported the authoritative process total and whether list process results were truncated by the requested limit.
 * Bounded shared, custom-indicator, and IOA pagination loops and rejected non-advancing server cursors.
+* Preserved detection and incident polling checkpoints when fetched records fail to persist in SOAR.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Removed executable asset preprocessing so asset configuration cannot run connector code.
+* Escaped connector widget values before embedding them in inline JavaScript handlers.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -8,3 +8,4 @@
 * Reported the authoritative process total and whether list process results were truncated by the requested limit.
 * Bounded shared, custom-indicator, and IOA pagination loops and rejected non-advancing server cursors.
 * Preserved detection and incident polling checkpoints when fetched records fail to persist in SOAR.
+* Reported sandbox detonation poll timeouts as action failures while retaining follow-up data.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -9,3 +9,4 @@
 * Bounded shared, custom-indicator, and IOA pagination loops and rejected non-advancing server cursors.
 * Preserved detection and incident polling checkpoints when fetched records fail to persist in SOAR.
 * Reported sandbox detonation poll timeouts as action failures while retaining follow-up data.
+* Protected detonation document passwords from action result parameter persistence.


### PR DESCRIPTION
Written by Codex.

PAPP: PAPP-37947

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->

- Removed executable asset preprocessing and its asset field, and escaped widget values embedded in JavaScript handlers.
- Structurally constrained run-query endpoint paths, encoded ingestion lookups, and limited container reuse to the active asset.
- Added authoritative truncation metadata and hard bounds/progress guards to process, shared, custom-indicator, IOA, and RTR result pagination.
- Preserved poll checkpoints on persistence failures, failed timed-out sandbox polling, and removed detonation document passwords from persisted action parameters.
- Preserved omitted IOA enabled state, redacted OAuth token endpoint debug data, positively verified resolved device targets, and surfaced device/indicator/mixed API errors as failures.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

### Other information

Breaking behavior:
- The `preprocess_script` asset configuration field and custom execution callback are removed.
- Omitting `enabled` from IOA update actions now preserves existing state instead of defaulting to false.

Validation and advisory-patch decisions:
- PSAAS-31586, PSAAS-31612, and PSAAS-31637 were rejected under the mutation-proof read-only policy; their declaration-only commit must not be carried into the SDK-based rewrite.
- The run-query restriction follows the connector's existing `/resource/queries/name/vN` endpoint shape and uses structural path-segment validation; it does not invent a resource allowlist.
- Device actions positively verify resolved hostnames/device IDs through the existing CrowdStrike device-details API path instead of imposing an inferred semantic character allowlist.
- Ingestion lookup uses structured request parameters and verifies the returned container asset ID.
- Password-typed output declarations remain because the required connector static test regenerates them; runtime `ActionResult` parameters omit the secret.
- `fix.patch` material was treated as advisory and adapted to the refreshed connector implementation.

PSAAS provenance:
- PSAAS-30576 (VULN-93301, FS-1005); PSAAS-30738 (VULN-93463, FS-1547); PSAAS-31125 (VULN-93850, FS-1967)
- PSAAS-31539 (VULN-94264, FS-2714); PSAAS-31666 (VULN-94391, FS-2909)
- PSAAS-31811 (VULN-94536, FS-3058); PSAAS-31814 (VULN-94539, FS-3061); PSAAS-31835 (VULN-94559, FS-3081); PSAAS-31873 (VULN-94597, FS-3119); PSAAS-31874 (VULN-94598, FS-3120)
- PSAAS-31994 (VULN-94718, FS-3240); PSAAS-32064 (VULN-94788, FS-3311); PSAAS-32103 (VULN-94827, FS-3350); PSAAS-32145 (VULN-94868, FS-3391)
- PSAAS-32174 (VULN-94897, FS-3420); PSAAS-32235 (VULN-94958, FS-3481); PSAAS-32304 (VULN-95027, FS-3550); PSAAS-32326 (VULN-95049, FS-3572)

Verification:
- `python3 -m py_compile` on connector and parser/view modules
- JSON parse, diff whitespace, prohibited version/minimum-version guards, and widget escaping scan
- `pre-commit run --all-files` passed, including Docker dependency packaging, SOAR app lint, semgrep, docs/notice/release-note generation, and static tests
- Integration tests were not run because this legacy connector's external asset tests are outside the pilot verification policy.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
