### PR TITLE
fix: recover publication of PR #90 security fixes

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Recover publication of PR #90 report-download security fixes.


### PR DESCRIPTION
Recovers publication of source PR #90, which merged while `call-publish.yml` was absent from its merge tree.

This adds a semantic `fix:` commit to trigger the workflow now present on `main`.

Validation: `git diff --check`; pre-commit static checks passed. Semgrep could not start under the local Python 3.14 hook environment.

Written by Codex.