### PR TITLE
fix!: harden CrowdStrike API result handling

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@ Third Party Software Attributions:
 
 @@@@============================================================================
 
-Library: Authlib - 1.7.2
+Library: Authlib - 1.7.1
 Homepage: https://github.com/authlib/authlib
 License: BSD License
 License Text:
@@ -3458,7 +3458,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @@@@============================================================================
 
-Library: splunk-soar-sdk - 3.26.4
+Library: splunk-soar-sdk - 3.27.2
 Homepage: https://github.com/phantomcyber/splunk-soar-sdk
 License: Apache-2.0
 License Text:

--- a/NOTICE
+++ b/NOTICE
@@ -3408,7 +3408,7 @@ Copyright 2014 Ian Cordasco, Cory Benfield
 
 @@@@============================================================================
 
-Library: rich - 15.0.0
+Library: rich - 14.3.4
 Homepage: https://github.com/Textualize/rich
 License: MIT License
 License Text:
@@ -3458,7 +3458,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @@@@============================================================================
 
-Library: splunk-soar-sdk - 3.26.1
+Library: splunk-soar-sdk - 3.26.4
 Homepage: https://github.com/phantomcyber/splunk-soar-sdk
 License: Apache-2.0
 License Text:

--- a/NOTICE
+++ b/NOTICE
@@ -3458,7 +3458,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @@@@============================================================================
 
-Library: splunk-soar-sdk - 3.27.2
+Library: splunk-soar-sdk - 3.28.1
 Homepage: https://github.com/phantomcyber/splunk-soar-sdk
 License: Apache-2.0
 License Text:

--- a/README.md
+++ b/README.md
@@ -1920,6 +1920,8 @@ action_result.data.\*.ioc | string | | |
 action_result.data.\*.ioc_type | string | | |
 action_result.data.\*.limit | numeric | | |
 action_result.summary.process_count | numeric | | |
+action_result.summary.total_process_count | numeric | | |
+action_result.summary.truncated | boolean | | True False |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pytz>=2023.3",
     "requests>=2.32.0",
     "requests-toolbelt==1.0.0",
-    "splunk-soar-sdk>=3.26.4",
+    "splunk-soar-sdk>=3.27.2",
 ]
 
 [tool.soar.app]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pytz>=2023.3",
     "requests>=2.32.0",
     "requests-toolbelt==1.0.0",
-    "splunk-soar-sdk>=3.26.1",
+    "splunk-soar-sdk>=3.26.4",
 ]
 
 [tool.soar.app]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pytz>=2023.3",
     "requests>=2.32.0",
     "requests-toolbelt==1.0.0",
-    "splunk-soar-sdk>=3.27.2",
+    "splunk-soar-sdk>=3.28.1",
 ]
 
 [tool.soar.app]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -8,3 +8,4 @@
 * Report detonation polling timeouts as action failures while preserving the resource ID for follow-up.
 * Reject device lookup metacharacters and verify resolved device identities before device actions.
 * Fail batch device and indicator operations when the API reports any item errors.
+* Escape dynamic values before embedding them in widget JavaScript string literals.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Update the Splunk SOAR SDK dependency to 3.26.4.
 * Bound pagination and stop when an API page makes no progress.
 * Report when list-process results are truncated from the API's authoritative total.
+* Bound command-result polling by time, sequence count, and response size.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,5 @@
 * Report when list-process results are truncated from the API's authoritative total.
 * Bound command-result polling by time, sequence count, and response size.
 * Report detonation polling timeouts as action failures while preserving the resource ID for follow-up.
+* Reject device lookup metacharacters and verify resolved device identities before device actions.
+* Fail batch device and indicator operations when the API reports any item errors.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,7 +1,7 @@
 **Unreleased**
 
 * Preserve the existing IOA rule and rule-group enabled state when the optional enabled parameter is omitted. This corrects the prior replace-style default and requires a major release.
-* Update the Splunk SOAR SDK dependency to 3.26.4.
+* Update the Splunk SOAR SDK dependency to 3.28.1.
 * Bound pagination and stop when an API page makes no progress.
 * Report when list-process results are truncated from the API's authoritative total.
 * Bound command-result polling by time, sequence count, and response size.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,6 +1,6 @@
 **Unreleased**
 
-* Preserve the existing IOA rule and rule-group enabled state when the optional enabled parameter is omitted.
+* Preserve the existing IOA rule and rule-group enabled state when the optional enabled parameter is omitted. This corrects the prior replace-style default and requires a major release.
 * Update the Splunk SOAR SDK dependency to 3.26.4.
 * Bound pagination and stop when an API page makes no progress.
 * Report when list-process results are truncated from the API's authoritative total.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Bound pagination and stop when an API page makes no progress.
 * Report when list-process results are truncated from the API's authoritative total.
 * Bound command-result polling by time, sequence count, and response size.
+* Report detonation polling timeouts as action failures while preserving the resource ID for follow-up.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,4 @@
 **Unreleased**
+
+* Preserve the existing IOA rule and rule-group enabled state when the optional enabled parameter is omitted.
+* Update the Splunk SOAR SDK dependency to 3.26.4.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,7 +1,6 @@
 **Unreleased**
 
 * Preserve the existing IOA rule and rule-group enabled state when the optional enabled parameter is omitted. This corrects the prior replace-style default and requires a major release.
-* Update the Splunk SOAR SDK dependency to 3.28.1.
 * Bound pagination and stop when an API page makes no progress.
 * Report when list-process results are truncated from the API's authoritative total.
 * Bound command-result polling by time, sequence count, and response size.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,5 @@
 
 * Preserve the existing IOA rule and rule-group enabled state when the optional enabled parameter is omitted.
 * Update the Splunk SOAR SDK dependency to 3.26.4.
+* Bound pagination and stop when an API page makes no progress.
+* Report when list-process results are truncated from the API's authoritative total.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -9,3 +9,4 @@
 * Reject device lookup metacharacters and verify resolved device identities before device actions.
 * Fail batch device and indicator operations when the API reports any item errors.
 * Escape dynamic values before embedding them in widget JavaScript string literals.
+* Validate generic query endpoints as canonical query paths before dispatch [PAPP-37947]

--- a/src/actions/detonate_file.py
+++ b/src/actions/detonate_file.py
@@ -12,6 +12,7 @@
 # and limitations under the License.
 
 from soar_sdk.abstract import SOARClient
+from soar_sdk.exceptions import ActionFailure
 from soar_sdk.params import Param, Params
 
 from ..app import Asset, app, get_client
@@ -210,7 +211,9 @@ def detonate_file(
         )
 
         poll_interval = validate_integer(asset.detonate_timeout, "detonate_timeout")
-        prev_resources, status = poll_for_detonation(client, resource_id, poll_interval)
+        _prev_resources, status = poll_for_detonation(
+            client, resource_id, poll_interval
+        )
 
         if status == "success":
             reports = fetch_reports(client, [resource_id], params.detail_report, None)
@@ -218,11 +221,10 @@ def detonate_file(
                 soar.set_summary(report_summary(reports))
             return _make_outputs(reports, params)
 
-        soar.set_message(
+        raise ActionFailure(
             f"Timed out while waiting for the result. To know the status of submitted "
             f"sample please run the check status action with {resource_id} resource id."
         )
-        return _make_outputs(prev_resources, params)
 
     if not resource_id_list:
         soar.set_message("No data found")

--- a/src/actions/detonate_url.py
+++ b/src/actions/detonate_url.py
@@ -12,6 +12,7 @@
 # and limitations under the License.
 
 from soar_sdk.abstract import SOARClient
+from soar_sdk.exceptions import ActionFailure
 from soar_sdk.params import Param, Params
 
 from ..app import Asset, app, get_client
@@ -192,7 +193,9 @@ def detonate_url(
         )
 
         poll_interval = validate_integer(asset.detonate_timeout, "detonate_timeout")
-        prev_resources, status = poll_for_detonation(client, resource_id, poll_interval)
+        _prev_resources, status = poll_for_detonation(
+            client, resource_id, poll_interval
+        )
 
         if status == "success":
             reports = fetch_reports(client, [resource_id], params.detail_report, None)
@@ -200,11 +203,10 @@ def detonate_url(
                 soar.set_summary(report_summary(reports))
             return _make_outputs(reports, params)
 
-        soar.set_message(
+        raise ActionFailure(
             f"Timed out while waiting for the result. To know the status of submitted "
             f"sample please run the check status action with {resource_id} resource id."
         )
-        return _make_outputs(prev_resources, params)
 
     if not resource_id_list:
         soar.set_message("No data found")

--- a/src/actions/list_custom_indicators.py
+++ b/src/actions/list_custom_indicators.py
@@ -230,7 +230,9 @@ def list_custom_indicators(
         api_data["filter"] = filter_query
 
     ioc_infos: list = []
-    while True:
+    previous_after = None
+    max_pages = (indicator_limit + 1_999) // 2_000 + 1
+    for _page in range(max_pages):
         response = client.make_rest_call(
             CROWDSTRIKE_GET_COMBINED_CUSTOM_INDICATORS_ENDPOINT, params=api_data
         )
@@ -243,17 +245,24 @@ def list_custom_indicators(
                 )
             )
 
-        if response.get("resources"):
-            ioc_infos.extend(response["resources"])
+        resources = response.get("resources", [])
+        if resources:
+            ioc_infos.extend(resources)
 
         after = response.get("meta", {}).get("pagination", {}).get("after")
         if after is None:
             break
 
+        if not resources or after == previous_after:
+            raise Exception("Pagination made no progress")
+
         if len(ioc_infos) >= indicator_limit:
             ioc_infos = ioc_infos[:indicator_limit]
             break
+        previous_after = after
         api_data["after"] = after
+    else:
+        raise Exception("Pagination exceeded the maximum page count")
 
     grouped: dict = {}
     for ioc_info in ioc_infos:

--- a/src/actions/list_processes.py
+++ b/src/actions/list_processes.py
@@ -52,6 +52,8 @@ class ListProcessesOutput(PermissiveActionOutput):
 
 class ListProcessesSummary(ActionOutput):
     process_count: int
+    total_process_count: int
+    truncated: bool
 
 
 @app.view_handler(template="crowdstrike_process_list_view.html")
@@ -103,7 +105,13 @@ def list_processes(
     response = client.hunt_paginator(CROWDSTRIKE_GET_PROCESSES_RAN_ON_APIPATH, api_data)
 
     if not response:
-        soar.set_summary(ListProcessesSummary(process_count=0))
+        soar.set_summary(
+            ListProcessesSummary(
+                process_count=0,
+                total_process_count=client._last_hunt_total,
+                truncated=False,
+            )
+        )
         soar.set_message(
             "No resources found from the response for the list processes action"
         )
@@ -120,6 +128,14 @@ def list_processes(
         for process_id in response
     ]
 
-    soar.set_summary(ListProcessesSummary(process_count=len(response)))
-    soar.set_message(f"Process count: {len(response)}")
+    total = max(client._last_hunt_total, len(response))
+    truncated = len(response) < total
+    soar.set_summary(
+        ListProcessesSummary(
+            process_count=len(response),
+            total_process_count=total,
+            truncated=truncated,
+        )
+    )
+    soar.set_message(f"Process count: {len(response)} of {total}")
     return outputs

--- a/src/actions/run_query.py
+++ b/src/actions/run_query.py
@@ -11,12 +11,41 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
+import re
+from urllib.parse import urlsplit
+
 from soar_sdk.abstract import SOARClient
 from soar_sdk.action_results import ActionOutput, OutputField
 from soar_sdk.params import Param, Params
 
 from ..app import Asset, app, get_client
 from ..consts import CROWDSTRIKE_INVALID_QUERY_ENDPOINT_MESSAGE_ERROR
+
+
+_QUERY_ENDPOINT_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_query_endpoint(endpoint: str) -> str:
+    parsed = urlsplit(endpoint)
+    segments = parsed.path.split("/")
+    valid_segments = (
+        len(segments) == 5
+        and segments[0] == ""
+        and segments[2].lower() == "queries"
+        and all(
+            segment not in {".", ".."} and _QUERY_ENDPOINT_SEGMENT.fullmatch(segment)
+            for segment in (segments[1], segments[3], segments[4])
+        )
+    )
+    if (
+        parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or not valid_segments
+    ):
+        raise ValueError(CROWDSTRIKE_INVALID_QUERY_ENDPOINT_MESSAGE_ERROR)
+    return endpoint
 
 
 class RunQueryParams(Params):
@@ -75,8 +104,7 @@ def run_query(
     if not endpoint:
         raise ValueError("Please provide endpoint path")
 
-    if "/queries/" not in endpoint.lower():
-        raise ValueError(CROWDSTRIKE_INVALID_QUERY_ENDPOINT_MESSAGE_ERROR)
+    endpoint = _validate_query_endpoint(endpoint)
 
     query_params: dict = {"limit": params.limit, "offset": params.offset}
     if params.filter:

--- a/src/actions/update_ioa_rule.py
+++ b/src/actions/update_ioa_rule.py
@@ -45,8 +45,8 @@ class UpdateIoaRuleParams(Params):
         description="JSON list of field values for the rule", required=True
     )
     comment: str = Param(description="Comment for the rule", required=False)
-    enabled: bool = Param(
-        description="Whether the rule is enabled", required=False, default=False
+    enabled: bool | None = Param(
+        description="Whether the rule is enabled", required=False
     )
 
 
@@ -153,7 +153,6 @@ def update_ioa_rule(
             {
                 "instance_id": params.rule_id,
                 "pattern_severity": params.severity,
-                "enabled": params.enabled,
                 "name": params.name,
                 "description": params.description,
                 "disposition_id": params.disposition_id,
@@ -161,6 +160,8 @@ def update_ioa_rule(
             }
         ],
     }
+    if params.enabled is not None:
+        update_params["rule_updates"][0]["enabled"] = params.enabled
     if params.comment:
         update_params["comment"] = params.comment
 

--- a/src/actions/update_ioa_rule_group.py
+++ b/src/actions/update_ioa_rule_group.py
@@ -32,10 +32,9 @@ class UpdateIoaRuleGroupParams(Params):
     version: int = Param(description="Version of the rule group", required=True)
     name: str = Param(description="Name of the rule group", required=True)
     description: str = Param(description="Description of the rule group", required=True)
-    enabled: bool = Param(
+    enabled: bool | None = Param(
         description="Whether the rule group is enabled",
         required=False,
-        default=False,
     )
     comment: str = Param(description="Comment for the update", required=True)
     assign_policy_id: str = Param(
@@ -110,9 +109,10 @@ def update_ioa_rule_group(
         "rulegroup_version": params.version,
         "name": params.name,
         "description": params.description,
-        "enabled": params.enabled,
         "comment": params.comment,
     }
+    if params.enabled is not None:
+        update_params["enabled"] = params.enabled
     resp_json = client.make_rest_call(
         CROWDSTRIKE_IOA_CREATE_RULE_GROUP_ENDPOINT,
         json_data=update_params,

--- a/src/helper.py
+++ b/src/helper.py
@@ -60,6 +60,9 @@ TOKEN_INVALID_MARKERS = (
     "access denied",
 )
 
+MAX_PAGINATION_PAGES = 1_000
+MAX_PAGINATION_RESULTS = 100_000
+
 
 class CrowdStrikeClient:
     """Multi-tenant OAuth2 client-credentials client for the CrowdStrike OAuth API.
@@ -76,6 +79,7 @@ class CrowdStrikeClient:
         self._client_secret = asset.client_secret
         self._stream_file_data = False
         self._required_detonation = False
+        self._last_hunt_total = 0
         self._tokens = self._load_tokens()
 
     # ------------------------------------------------------------------ #
@@ -429,8 +433,7 @@ class CrowdStrikeClient:
         param: dict | None = None,
         subtenant: str | None = None,
     ) -> list:
-        if param is None:
-            param = {}
+        param = dict(param or {})
         list_ids = []
 
         limit = None
@@ -438,16 +441,28 @@ class CrowdStrikeClient:
             limit = int(param.pop("limit"))
         offset = param.get("offset", 0)
 
+        page_count = 0
         while True:
+            page_count += 1
+            if page_count > MAX_PAGINATION_PAGES:
+                raise Exception("Pagination exceeded the maximum page count")
             param.update({"offset": offset})
             response = self.make_rest_call(endpoint, params=param, subtenant=subtenant)
 
             prev_offset = offset
-            offset = response.get("meta", {}).get("pagination", {}).get("offset")
-            if offset == prev_offset:
-                offset += len(response.get("resources", []))
+            pagination = response.get("meta", {}).get("pagination", {})
+            offset = pagination.get("offset")
+            total = pagination.get("total")
+            if not isinstance(offset, int) or offset < 0:
+                raise Exception("Invalid pagination offset returned by server")
+            if not isinstance(total, int) or total < 0:
+                raise Exception("Invalid pagination total returned by server")
 
-            total = response.get("meta", {}).get("pagination", {}).get("total")
+            resources = response.get("resources", [])
+            if not isinstance(resources, list):
+                raise Exception("Invalid paginated resources returned by server")
+            if offset == prev_offset:
+                offset += len(resources)
 
             if response.get("errors"):
                 error = response["errors"][0]
@@ -457,13 +472,13 @@ class CrowdStrikeClient:
                     )
                 )
 
-            if offset is None or total is None:
-                raise Exception(
-                    "Error occurred in fetching 'offset' and 'total' key-values while fetching paginated results"
-                )
+            if resources:
+                list_ids.extend(resources)
+            elif offset < total:
+                raise Exception("Pagination made no progress")
 
-            if response.get("resources"):
-                list_ids.extend(response["resources"])
+            if len(list_ids) > MAX_PAGINATION_RESULTS:
+                raise Exception("Pagination exceeded the maximum result count")
 
             if limit and len(list_ids) >= limit:
                 return list_ids[:limit]
@@ -474,6 +489,9 @@ class CrowdStrikeClient:
             if offset >= total:
                 return list_ids
 
+            if offset <= prev_offset:
+                raise Exception("Pagination made no progress")
+
     def hunt_paginator(
         self,
         endpoint: str,
@@ -481,8 +499,8 @@ class CrowdStrikeClient:
         search_subtenants: bool = False,
         subtenant: str | None = None,
     ) -> list:
+        params = dict(params)
         list_ids = []
-        offset = ""
         limit = None
         if params.get("limit"):
             limit = params.pop("limit")
@@ -497,8 +515,16 @@ class CrowdStrikeClient:
             if configured:
                 subtenants.extend(configured)
 
+        self._last_hunt_total = 0
         for sub in subtenants:
+            offset = ""
+            subtenant_result_start = len(list_ids)
+            page_count = 0
+            recorded_total = False
             while True:
+                page_count += 1
+                if page_count > MAX_PAGINATION_PAGES:
+                    raise Exception("Pagination exceeded the maximum page count")
                 params.update({"offset": offset, "limit": 100})
                 try:
                     response = self.make_rest_call(
@@ -509,7 +535,16 @@ class CrowdStrikeClient:
                         break
                     raise
 
-                offset = response.get("meta", {}).get("pagination", {}).get("offset")
+                pagination = response.get("meta", {}).get("pagination", {})
+                next_offset = pagination.get("offset")
+                resources = response.get("resources", [])
+                if not isinstance(resources, list):
+                    raise Exception("Invalid paginated resources returned by server")
+
+                total = pagination.get("total")
+                if not recorded_total and isinstance(total, int) and total >= 0:
+                    self._last_hunt_total += total
+                    recorded_total = True
 
                 if response.get("errors"):
                     error = response["errors"][0]
@@ -519,16 +554,25 @@ class CrowdStrikeClient:
                         )
                     )
 
-                if response.get("resources"):
-                    list_ids.extend(response["resources"])
+                if resources:
+                    list_ids.extend(resources)
+
+                if len(list_ids) > MAX_PAGINATION_RESULTS:
+                    raise Exception("Pagination exceeded the maximum result count")
 
                 if limit and len(list_ids) >= limit:
                     return list_ids[:limit]
 
-                if not offset and not response.get("meta", {}).get(
-                    "pagination", {}
-                ).get("next_page"):
+                has_next_page = bool(pagination.get("next_page"))
+                if not next_offset and not has_next_page:
                     break
+
+                if not resources or next_offset == offset:
+                    raise Exception("Pagination made no progress")
+                offset = next_offset
+
+            if not recorded_total:
+                self._last_hunt_total += len(list_ids) - subtenant_result_start
 
         return list_ids
 

--- a/src/helper.py
+++ b/src/helper.py
@@ -62,6 +62,7 @@ TOKEN_INVALID_MARKERS = (
 
 MAX_PAGINATION_PAGES = 1_000
 MAX_PAGINATION_RESULTS = 100_000
+MAX_COMMAND_RESULT_BYTES = 10 * 1024 * 1024
 
 
 class CrowdStrikeClient:
@@ -793,42 +794,68 @@ class CrowdStrikeClient:
     ) -> list:
         """Poll for RTR command results. Returns the list of polled response dicts."""
         timeout_segment_length = 5
-        timeout_segments = timeout / timeout_segment_length
-
+        deadline = time.monotonic() + timeout
         results: list = []
-        count = 0
-        while count < int(timeout_segments):
-            count += 1
+        while time.monotonic() < deadline:
             sequence_id = 0
             params = {"cloud_request_id": cloud_request_id, "sequence_id": sequence_id}
             resp_json = self.make_rest_call(endpoint, params=params)
 
             resources = resp_json.get("resources")
-            if resources and len(resources):
+            if resources:
                 if resources[0].get("complete", False):
-                    while True:
+                    result_bytes = 0
+                    previous_response_sequence = None
+                    for _page in range(MAX_PAGINATION_PAGES):
+                        if time.monotonic() >= deadline:
+                            raise Exception(
+                                "Timeout while fetching command result sequences"
+                            )
                         params = {
                             "cloud_request_id": cloud_request_id,
                             "sequence_id": sequence_id,
                         }
                         resp_json = self.make_rest_call(endpoint, params=params)
+                        errors = resp_json.get("errors", [])
+                        if errors:
+                            raise Exception(
+                                "Errors occurred while executing command: {}".format(
+                                    "\r\n".join(
+                                        str(error.get("message")) for error in errors
+                                    )
+                                )
+                            )
 
-                        if (
-                            resources[0].get("complete")
-                            and resources[0].get("stderr") is not None
-                            and resp_json.get("resources", [{}])[0].get("sequence_id")
-                        ):
+                        page_resources = resp_json.get("resources", [])
+                        if not page_resources:
+                            raise Exception(
+                                "Command result sequence returned no resources"
+                            )
+                        resource = page_resources[0]
+                        if resource.get("stderr"):
                             raise Exception(
                                 "Errors occurred while executing command {}".format(
-                                    "\r\n".join(resources[0].get("stderr"))
+                                    "\r\n".join(resource["stderr"])
                                 )
                             )
 
                         results.append(resp_json)
-                        if not resp_json.get("resources", [{}])[0].get("sequence_id"):
+                        result_bytes += len(json.dumps(resp_json, default=str))
+                        if result_bytes > MAX_COMMAND_RESULT_BYTES:
+                            raise Exception("Command results exceeded the maximum size")
+
+                        response_sequence = resource.get("sequence_id")
+                        if not response_sequence:
                             return results
 
+                        if response_sequence == previous_response_sequence:
+                            raise Exception("Command result sequence made no progress")
+                        previous_response_sequence = response_sequence
+
                         sequence_id += 1
+                    raise Exception(
+                        "Command results exceeded the maximum sequence count"
+                    )
             elif len(resp_json.get("errors", [])):
                 errors = [err.get("message") for err in resp_json.get("errors")]
                 raise Exception(
@@ -837,7 +864,7 @@ class CrowdStrikeClient:
                     )
                 )
 
-            time.sleep(timeout_segment_length)
+            time.sleep(min(timeout_segment_length, max(0, deadline - time.monotonic())))
 
         raise Exception(
             "Timeout while waiting for command execution. Please use cloud_request_id "

--- a/src/helper.py
+++ b/src/helper.py
@@ -29,6 +29,7 @@ from .consts import (
     CROWDSTRIKE_DEFAULT_TIMEOUT,
     CROWDSTRIKE_DEVICE_ACTION_ENDPOINT,
     CROWDSTRIKE_DOWNLOAD_REPORT_ENDPOINT,
+    CROWDSTRIKE_GET_DEVICE_DETAILS_ENDPOINT,
     CROWDSTRIKE_GET_DEVICE_ID_ENDPOINT,
     CROWDSTRIKE_GET_EXTRACTED_RTR_FILE_ENDPOINT,
     CROWDSTRIKE_GROUP_DEVICE_ACTION_ENDPOINT,
@@ -389,29 +390,12 @@ class CrowdStrikeClient:
         except Exception as e:
             raise Exception(f"Unable to parse JSON response. Error: {e}") from e
 
-        resources = resp_json.get("resources")
         errors = resp_json.get("errors")
-        if "resources" in resp_json and "errors" in resp_json and errors:
-            if not resources:
-                error_msg = ", ".join(
-                    "{} - {}".format(err.get("code"), err.get("message"))
-                    for err in errors
-                )
-                raise Exception(f"Error from server. Error details: {error_msg}")
-            if (
-                resources
-                and isinstance(resources, list)
-                and resources[0].get("message")
-            ):
-                error_msg = ", ".join(
-                    "{} - {}".format(err.get("code"), err.get("message"))
-                    for err in errors
-                )
-                raise Exception(
-                    "Error from server. Error details: {}, {}".format(
-                        error_msg, resources[0]["message"]
-                    )
-                )
+        if errors:
+            error_msg = ", ".join(
+                "{} - {}".format(err.get("code"), err.get("message")) for err in errors
+            )
+            raise Exception(f"Error from server. Error details: {error_msg}")
 
         if 200 <= response.status_code < 399:
             return resp_json
@@ -621,6 +605,13 @@ class CrowdStrikeClient:
         Returns (flag, confirmed_ids). ``flag`` is True when some inputs could not
         be resolved (count mismatch), in which case ``confirmed_ids`` is empty.
         """
+        if key == "device_id":
+            valid_item = re.compile(r"^[A-Fa-f0-9]{32}$").fullmatch
+        else:
+            valid_item = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$").fullmatch
+        if any(not valid_item(item) for item in list_items):
+            return True, []
+
         filter_str = "".join(f"{key}: '{item}', " for item in list_items)
         filter_str = filter_str[:-2]
 
@@ -630,9 +621,40 @@ class CrowdStrikeClient:
             subtenant=subtenant,
         )
 
-        if len(list_items) != len(check_items):
+        resolved_ids = list(check_items)
+        if len(list_items) != len(resolved_ids):
             return True, []
-        return False, list(check_items)
+
+        if key == "device_id":
+            if {item.casefold() for item in list_items} != {
+                item.casefold() for item in resolved_ids
+            }:
+                return True, []
+            return False, resolved_ids
+
+        id_tenant_map = (
+            check_items
+            if isinstance(check_items, dict)
+            else {device_id: subtenant for device_id in resolved_ids}
+        )
+        tenant_ids: dict = {}
+        for device_id, tenant in id_tenant_map.items():
+            tenant_ids.setdefault(tenant, []).append(device_id)
+
+        resolved_hostnames = set()
+        for tenant, device_ids in tenant_ids.items():
+            response = self.make_rest_call(
+                CROWDSTRIKE_GET_DEVICE_DETAILS_ENDPOINT,
+                json_data={"ids": device_ids},
+                subtenant=tenant,
+            )
+            resolved_hostnames.update(
+                str(device.get("hostname", "")).casefold()
+                for device in response.get("resources", [])
+            )
+        if {item.casefold() for item in list_items} != resolved_hostnames:
+            return True, []
+        return False, resolved_ids
 
     def check_device_params(self, param: dict, subtenant: str | None = None) -> list:
         """Validate and resolve device_id/hostname params into a device-ID list."""
@@ -753,16 +775,17 @@ class CrowdStrikeClient:
                     subtenant=subtenant,
                     method="post",
                 )
-                if not response.get("resources"):
+                resources = response.get("resources", [])
+                if len(resources) != len(batch):
                     raise ValueError(
-                        "No action could be performed on the provided devices"
+                        "The device action did not complete for every requested device"
                     )
-                results.extend(response.get("resources"))
+                results.extend(resources)
                 del list_ids[: min(100, len(list_ids))]
             return results
 
         if action_name in ("add-hosts", "remove-hosts"):
-            response = {}
+            results = []
             while list_ids:
                 batch = list_ids[: min(100, len(list_ids))]
                 data = {
@@ -777,11 +800,12 @@ class CrowdStrikeClient:
                     data=json.dumps(data),
                     method="post",
                 )
+                if not response.get("resources"):
+                    raise ValueError(
+                        "No action could be performed on the provided devices"
+                    )
+                results.extend(response["resources"])
                 del list_ids[: min(100, len(list_ids))]
-
-            if not response.get("resources"):
-                raise ValueError("No action could be performed on the provided devices")
-            results.extend(response.get("resources"))
             return results
 
         raise ValueError("Incorrect action name")

--- a/templates/crowdstrike_command_output.html
+++ b/templates/crowdstrike_command_output.html
@@ -95,7 +95,7 @@
                           <td>{{ field.base_command }}</td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ field.session_id }}' }], 0, {{ container }}, null, false);">{{ field.session_id }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ field.session_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ field.session_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/templates/crowdstrike_create_ioa_rule.html
+++ b/templates/crowdstrike_create_ioa_rule.html
@@ -122,7 +122,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.rulegroup_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.rulegroup_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.rulegroup_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -131,7 +131,7 @@
                           <td>{{ resource.magic_cookie }}</td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ resource.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ resource.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.instance_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_create_ioa_rule_group.html
+++ b/templates/crowdstrike_create_ioa_rule_group.html
@@ -117,7 +117,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -158,7 +158,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ resource.id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -166,7 +166,7 @@
                             </td>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ policy_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_create_session.html
+++ b/templates/crowdstrike_create_session.html
@@ -78,7 +78,7 @@
               <td>Device ID</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ session.device_id }}' }], 0, {{ container }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ session.device_id|escapejs }}' }], 0, {{ container }}, null, false);">
                   {{ session.device_id }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -100,7 +100,7 @@
                 <tr>
                   <td>
                     <a href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ resource.session_id }}' }], 0, {{ container }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['crowdstrike rtr session id'], 'value': '{{ resource.session_id|escapejs }}' }], 0, {{ container }}, null, false);">
                       {{ resource.session_id }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -109,7 +109,7 @@
                   <td>{{ resource.created_at }}</td>
                   <td>
                     <a href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ resource.pwd }}' }], 0, {{ container }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ resource.pwd|escapejs }}' }], 0, {{ container }}, null, false);">
                       {{ resource.pwd }}
                       &nbsp;
                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_delete_indicator.html
+++ b/templates/crowdstrike_delete_indicator.html
@@ -87,7 +87,7 @@ a:hover {
             {% if result.param.ioc %}
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': [ 'ip', 'ipv6', 'sha256', 'md5', 'domain' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': [ 'ip', 'ipv6', 'sha256', 'md5', 'domain' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.ioc }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -96,7 +96,7 @@ a:hover {
             {% if result.param.resource_id %}
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator id' ], 'value': '{{ result.param.resource_id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator id' ], 'value': '{{ result.param.resource_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.resource_id }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>

--- a/templates/crowdstrike_detonate_file.html
+++ b/templates/crowdstrike_detonate_file.html
@@ -110,7 +110,7 @@
                 <td>Vault ID</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.vault_id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -122,7 +122,7 @@
               <td>Environment Description</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.environment }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -190,7 +190,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -224,7 +224,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -236,7 +236,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -248,7 +248,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -260,7 +260,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -272,7 +272,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -284,7 +284,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -296,7 +296,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -308,7 +308,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -323,7 +323,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -341,7 +341,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -361,7 +361,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -382,7 +382,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_detonate_url.html
+++ b/templates/crowdstrike_detonate_url.html
@@ -110,7 +110,7 @@
                 <td>URL</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.url }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -122,7 +122,7 @@
               <td>Environment Description</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['crowdstrike environment'], 'value': '{{ result.param.environment|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.environment }}
                   &nbsp;
                   <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -190,7 +190,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -224,7 +224,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -236,7 +236,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -248,7 +248,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -260,7 +260,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -272,7 +272,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -284,7 +284,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -296,7 +296,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -308,7 +308,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -323,7 +323,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -341,7 +341,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -361,7 +361,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -382,7 +382,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_file_reputation.html
+++ b/templates/crowdstrike_file_reputation.html
@@ -110,7 +110,7 @@
                 <td>Vault ID</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['vault id'], 'value': '{{ result.param.vault_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.vault_id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -179,7 +179,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -213,7 +213,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -225,7 +225,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -237,7 +237,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -249,7 +249,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -261,7 +261,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -273,7 +273,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -285,7 +285,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -297,7 +297,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -312,7 +312,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -330,7 +330,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -350,7 +350,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -371,7 +371,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_get_alerts_details.html
+++ b/templates/crowdstrike_get_alerts_details.html
@@ -94,14 +94,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id }}' }], 0, {{ container }}, null, false);">{{ data.composite_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ data.composite_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/templates/crowdstrike_get_detections_details.html
+++ b/templates/crowdstrike_get_detections_details.html
@@ -94,14 +94,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id }}' }], 0, {{ container }}, null, false);">{{ data.detection_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ data.detection_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/templates/crowdstrike_get_device_scroll.html
+++ b/templates/crowdstrike_get_device_scroll.html
@@ -155,7 +155,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ resource }}' }], 0, {{ container.id }}, null, false);">{{ resource }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ resource|escapejs }}' }], 0, {{ container.id }}, null, false);">{{ resource }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/templates/crowdstrike_get_indicator.html
+++ b/templates/crowdstrike_get_indicator.html
@@ -117,7 +117,7 @@
                         <td>
                           {% if resource.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -129,7 +129,7 @@
                         <td>
                           {% if resource.type %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator type'], 'value': '{{ resource.type }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator type'], 'value': '{{ resource.type|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.type }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -141,7 +141,7 @@
                         <td>
                           {% if resource.value %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': [ 'domain', 'ip', 'ipv6', 'sha256', 'md5' ], 'value': '{{ resource.value }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': [ 'domain', 'ip', 'ipv6', 'sha256', 'md5' ], 'value': '{{ resource.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.value }}
                               &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -152,7 +152,7 @@
                         <td>
                           {% if resource.action %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ resource.action }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ resource.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.action }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -167,7 +167,7 @@
                         <td>
                           {% if resource.severity %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ resource.severity }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ resource.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.severity }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -182,7 +182,7 @@
                               {% for platform in resource.platforms %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike indicator platforms'], 'value': '{{ platform }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike indicator platforms'], 'value': '{{ platform|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ platform }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_get_user_roles.html
+++ b/templates/crowdstrike_get_user_roles.html
@@ -112,7 +112,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike user role id'], 'value': '{{ item.role_name }}' }], 0, {{ container }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike user role id'], 'value': '{{ item.role_name|escapejs }}' }], 0, {{ container }}, null, false);">
                             {{ item.role_name }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_get_zta_data.html
+++ b/templates/crowdstrike_get_zta_data.html
@@ -114,7 +114,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ item.aid }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ item.aid|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item.aid }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -122,7 +122,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ item.cid }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ item.cid|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item.cid }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_host_group.html
+++ b/templates/crowdstrike_host_group.html
@@ -74,7 +74,7 @@
               <tr>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ group.id }}' }], 0, {{ container }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['crowdstrike host group id'], 'value': '{{ group.id|escapejs }}' }], 0, {{ container }}, null, false);">
                     {{ group.id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_hunt_view.html
+++ b/templates/crowdstrike_hunt_view.html
@@ -111,7 +111,7 @@
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type }}' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type|escapejs }}' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.ioc }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -153,7 +153,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ curr_entry.device_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ curr_entry.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ curr_entry.device_id }}
                               &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/templates/crowdstrike_list_custom_indicators.html
+++ b/templates/crowdstrike_list_custom_indicators.html
@@ -168,7 +168,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['md5'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['md5'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -180,7 +180,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -192,7 +192,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -232,7 +232,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -244,7 +244,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -256,7 +256,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -296,7 +296,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -308,7 +308,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -320,7 +320,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -360,7 +360,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -372,7 +372,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -384,7 +384,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -424,7 +424,7 @@ a:hover {
                       <td>
                         {% if curr_entry.value %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ curr_entry.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.value }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -436,7 +436,7 @@ a:hover {
                       <td>
                         {% if curr_entry.severity %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['severity'], 'value': '{{ curr_entry.severity|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.severity }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -448,7 +448,7 @@ a:hover {
                       <td>
                         {% if curr_entry.action %}
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike indicator action'], 'value': '{{ curr_entry.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.action }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_list_detections.html
+++ b/templates/crowdstrike_list_detections.html
@@ -72,7 +72,7 @@
               <tr>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id }}' }], 0, {{ container }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['crowdstrike detection id'], 'value': '{{ data.detection_id|escapejs }}' }], 0, {{ container }}, null, false);">
                     {{ data.detection_id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -80,7 +80,7 @@
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container }}, null, false);">
                     {{ data.device.device_id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_list_epp_alerts.html
+++ b/templates/crowdstrike_list_epp_alerts.html
@@ -90,14 +90,14 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id }}' }], 0, {{ container }}, null, false);">{{ data.composite_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike alert id'], 'value': '{{ data.composite_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ data.composite_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id }}' }], 0, {{ container }}, null, false);">{{ data.device.device_id }}
+                             onclick="context_menu(this, [{'contains': ['crowdstrike device id'], 'value': '{{ data.device.device_id|escapejs }}' }], 0, {{ container }}, null, false);">{{ data.device.device_id }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/templates/crowdstrike_list_incident_behaviors.html
+++ b/templates/crowdstrike_list_incident_behaviors.html
@@ -163,7 +163,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike incidentbehavior id'], 'value': '{{ item }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike incidentbehavior id'], 'value': '{{ item|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_list_incidents.html
+++ b/templates/crowdstrike_list_incidents.html
@@ -163,7 +163,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['crowdstrike incident id'], 'value': '{{ item }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['crowdstrike incident id'], 'value': '{{ item|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ item }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_list_ioa_rule_groups.html
+++ b/templates/crowdstrike_list_ioa_rule_groups.html
@@ -95,7 +95,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -131,7 +131,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id }}' }], 0, {{ container }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id|escapejs }}' }], 0, {{ container }}, null, false);">
                                 {{ rule.instance_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_list_users.html
+++ b/templates/crowdstrike_list_users.html
@@ -131,21 +131,21 @@
                           <td>{{ resource.last_name }}</td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike user id'], 'value': '{{ resource.uid }}' }], 0, {{ container }}, null, false);">{{ resource.uid }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike user id'], 'value': '{{ resource.uid|escapejs }}' }], 0, {{ container }}, null, false);">{{ resource.uid }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike unique user id'], 'value': '{{ resource.uuid }}' }], 0, {{ container }}, null, false);">{{ resource.uuid }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike unique user id'], 'value': '{{ resource.uuid|escapejs }}' }], 0, {{ container }}, null, false);">{{ resource.uuid }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ resource.cid }}' }], 0, {{ container }}, null, false);">{{ resource.cid }}
+                               onclick="context_menu(this, [{'contains': ['crowdstrike customer id'], 'value': '{{ resource.cid|escapejs }}' }], 0, {{ container }}, null, false);">{{ resource.cid }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/templates/crowdstrike_process_list_view.html
+++ b/templates/crowdstrike_process_list_view.html
@@ -115,7 +115,7 @@
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ result.param.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': [ 'crowdstrike device id' ], 'value': '{{ result.param.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.id }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -127,7 +127,7 @@
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type }}' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type|escapejs }}' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.ioc }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -168,7 +168,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': [ 'falcon process id' ], 'value': '{{ curr_entry.falcon_process_id }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': [ 'falcon process id' ], 'value': '{{ curr_entry.falcon_process_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ curr_entry.falcon_process_id }}
                             &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>

--- a/templates/crowdstrike_set_status_view.html
+++ b/templates/crowdstrike_set_status_view.html
@@ -87,7 +87,7 @@ a:hover {
           <tr>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': [ 'falcon detection id' ], 'value': '{{ result.param.id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': [ 'falcon detection id' ], 'value': '{{ result.param.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.id }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>

--- a/templates/crowdstrike_update_indicator.html
+++ b/templates/crowdstrike_update_indicator.html
@@ -86,14 +86,14 @@ a:hover {
           <tr>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type }}' ], 'value': '{{ result.param.ioc }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': [ '{{ result.param.ioc_type|escapejs }}' ], 'value': '{{ result.param.ioc|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.ioc }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator action' ], 'value': '{{ result.param.action }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': [ 'crowdstrike indicator action' ], 'value': '{{ result.param.action|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.action }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>

--- a/templates/crowdstrike_update_ioa_rule.html
+++ b/templates/crowdstrike_update_ioa_rule.html
@@ -117,7 +117,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -165,7 +165,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ rule.instance_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_update_ioa_rule_group.html
+++ b/templates/crowdstrike_update_ioa_rule_group.html
@@ -117,7 +117,7 @@
                         <tr>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ resource.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -165,7 +165,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule id'], 'value': '{{ rule.instance_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ rule.instance_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -210,7 +210,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ resource.id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -218,7 +218,7 @@
                             </td>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ policy_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -254,7 +254,7 @@
                           <tr>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike ioa rule group id'], 'value': '{{ resource.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ resource.id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -262,7 +262,7 @@
                             </td>
                             <td>
                               <a href="javascript:;"
-                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id }}' }], 0, {{ container.id }}, null, false);">
+                                 onclick="context_menu(this, [{'contains': ['crowdstrike prevention policy id'], 'value': '{{ policy_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                 {{ policy_id }}
                                 &nbsp;
                                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/templates/crowdstrike_url_reputation.html
+++ b/templates/crowdstrike_url_reputation.html
@@ -110,7 +110,7 @@
                 <td>URL</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ result.param.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.param.url }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -179,7 +179,7 @@
                         <td>
                           {% if item.id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike resource id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -213,7 +213,7 @@
                         <td>
                           {% if item.ioc_report_broad_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -225,7 +225,7 @@
                         <td>
                           {% if item.ioc_report_broad_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -237,7 +237,7 @@
                         <td>
                           {% if item.ioc_report_broad_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -249,7 +249,7 @@
                         <td>
                           {% if item.ioc_report_broad_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_broad_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_broad_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -261,7 +261,7 @@
                         <td>
                           {% if item.ioc_report_strict_csv_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_csv_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_csv_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -273,7 +273,7 @@
                         <td>
                           {% if item.ioc_report_strict_json_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_json_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_json_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -285,7 +285,7 @@
                         <td>
                           {% if item.ioc_report_strict_maec_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_maec_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_maec_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -297,7 +297,7 @@
                         <td>
                           {% if item.ioc_report_strict_stix_artifact_id %}
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ item.ioc_report_strict_stix_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ item.ioc_report_strict_stix_artifact_id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -312,7 +312,7 @@
                               {% if analysis.pcap_report_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.pcap_report_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.pcap_report_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -330,7 +330,7 @@
                               {% if analysis.memory_strings_artifact_id %}
                                 <li style="list-style-type: none;">
                                   <a href="javascript:;"
-                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                     onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ analysis.memory_strings_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                     {{ analysis.memory_strings_artifact_id }}
                                     &nbsp;
                                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -350,7 +350,7 @@
                                   {% if process.icon_artifact_id %}
                                     <li style="list-style-type: none;">
                                       <a href="javascript:;"
-                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                         onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ process.icon_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                         {{ process.icon_artifact_id }}
                                         &nbsp;
                                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -371,7 +371,7 @@
                                 {% for screenshot_artifact_id in analysis.screenshots_artifact_ids %}
                                   <li style="list-style-type: none;">
                                     <a href="javascript:;"
-                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id }}' }], 0, {{ container.id }}, null, false);">
+                                       onclick="context_menu(this, [{'contains': ['crowdstrike artifact id'], 'value': '{{ screenshot_artifact_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                                       {{ screenshot_artifact_id }}
                                       &nbsp;
                                       <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -76,3 +76,31 @@ def test_command_result_polling_rejects_repeated_sequence() -> None:
 
     with pytest.raises(Exception, match="sequence made no progress"):
         client.poll_command_results("request-id", timeout=60)
+
+
+def test_json_response_rejects_partial_success() -> None:
+    client = object.__new__(CrowdStrikeClient)
+    response = Mock(
+        status_code=202,
+        json=Mock(
+            return_value={
+                "resources": [{"id": "ok"}],
+                "errors": [{"code": 404, "message": "failed"}],
+            }
+        ),
+    )
+
+    with pytest.raises(Exception, match="404 - failed"):
+        client._process_json_response(response)
+
+
+@pytest.mark.parametrize("value", ["host*", "host'", "host+other", "host(test)"])
+def test_device_lookup_rejects_fql_metacharacters(value: str) -> None:
+    client = object.__new__(CrowdStrikeClient)
+    client.get_ids_with_subtenants = Mock()
+
+    invalid, resolved = client._set_error_flag_inputs([value], "hostname")
+
+    assert invalid is True
+    assert resolved == []
+    client.get_ids_with_subtenants.assert_not_called()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -65,3 +65,14 @@ def test_hunt_paginator_records_authoritative_total() -> None:
         "second",
     ]
     assert client._last_hunt_total == 250
+
+
+def test_command_result_polling_rejects_repeated_sequence() -> None:
+    client = _client(
+        {"resources": [{"complete": True}]},
+        {"resources": [{"complete": True, "sequence_id": 1, "stdout": "a"}]},
+        {"resources": [{"complete": True, "sequence_id": 1, "stdout": "b"}]},
+    )
+
+    with pytest.raises(Exception, match="sequence made no progress"):
+        client.poll_command_results("request-id", timeout=60)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.helper import CrowdStrikeClient
+
+
+def _client(*responses: dict) -> CrowdStrikeClient:
+    client = object.__new__(CrowdStrikeClient)
+    client._required_detonation = False
+    client._last_hunt_total = 0
+    client.make_rest_call = Mock(side_effect=responses)
+    return client
+
+
+def test_paginator_rejects_empty_nonterminal_page() -> None:
+    client = _client(
+        {"meta": {"pagination": {"offset": 0, "total": 2}}, "resources": []}
+    )
+
+    with pytest.raises(Exception, match="made no progress"):
+        client.paginator("/queries/example/v1")
+
+
+def test_hunt_paginator_rejects_repeated_cursor() -> None:
+    client = _client(
+        {
+            "meta": {"pagination": {"offset": "same", "next_page": "next"}},
+            "resources": ["first"],
+        },
+        {
+            "meta": {"pagination": {"offset": "same", "next_page": "next"}},
+            "resources": ["second"],
+        },
+    )
+
+    with pytest.raises(Exception, match="made no progress"):
+        client.hunt_paginator("/queries/example/v1", {})
+
+
+def test_hunt_paginator_records_authoritative_total() -> None:
+    client = _client(
+        {
+            "meta": {"pagination": {"offset": None, "total": 250}},
+            "resources": ["first", "second"],
+        }
+    )
+
+    assert client.hunt_paginator("/queries/example/v1", {"limit": 2}) == [
+        "first",
+        "second",
+    ]
+    assert client._last_hunt_total == 250

--- a/tests/test_run_query_endpoint.py
+++ b/tests/test_run_query_endpoint.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from src.actions.run_query import _validate_query_endpoint
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/devices/queries/devices/v1",
+        "/real-time-response/queries/sessions/v1",
+        "/ioarules/queries/rule-groups-full/v1",
+    ],
+)
+def test_validate_query_endpoint_accepts_structural_query_paths(endpoint):
+    assert _validate_query_endpoint(endpoint) == endpoint
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/installation-tokens/entities/tokens/v1?next=/devices/queries/devices/v1",
+        "/real-time-response/entities/sessions/v1#/devices/queries/devices/v1",
+        "https://example.invalid/devices/queries/devices/v1",
+        "/devices/queries/../v1",
+        "/devices/queries/devices%2fother/v1",
+        "/devices/queries/devices/v1/extra",
+        "devices/queries/devices/v1",
+    ],
+)
+def test_validate_query_endpoint_rejects_non_query_or_ambiguous_paths(endpoint):
+    with pytest.raises(ValueError, match="query endpoint"):
+        _validate_query_endpoint(endpoint)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from pathlib import Path
+
+
+UNESCAPED_JS_TEMPLATE_VALUE = re.compile(r"'\{\{(?![^}]*\|escapejs)[^}]+\}\}'")
+
+
+def test_widget_javascript_string_values_are_escaped() -> None:
+    templates = Path("templates").glob("*.html")
+    failures = []
+    for template in templates:
+        for line_number, line in enumerate(template.read_text().splitlines(), 1):
+            if "onclick=" in line and UNESCAPED_JS_TEMPLATE_VALUE.search(line):
+                failures.append(f"{template}:{line_number}")
+
+    assert failures == []

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2023.3" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "requests-toolbelt", specifier = "==1.0.0" },
-    { name = "splunk-soar-sdk", specifier = ">=3.27.2" },
+    { name = "splunk-soar-sdk", specifier = ">=3.28.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1050,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "3.27.2"
+version = "3.28.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1076,9 +1076,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/61/6ee011e2f7cb8a0bc9332aa40b1d8ebd25612d62e720b3cc58cfe9a9c4da/splunk_soar_sdk-3.27.2.tar.gz", hash = "sha256:a9ffc36fd79344ab3acff9087df64a50980a2b40779b0039af53755a910773a4", size = 759706, upload-time = "2026-08-03T22:33:46.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/99/fcb72f4846441e7576009c4f322d36906b124fa450d2d94e310c8f4d796d/splunk_soar_sdk-3.28.1.tar.gz", hash = "sha256:1d0ccb7e6619e112e29f06cc99ce8070c2f383f950959a08d888f693285fcaca", size = 761311, upload-time = "2026-08-06T22:45:20.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/7b/36ca02bf9dd7457c16615aa2914de7556e780e9e5d2c3c90dac237756973/splunk_soar_sdk-3.27.2-py3-none-any.whl", hash = "sha256:a605057e1fea2a27e99f48e1e62fddf4167d59af8b34e8eb9a0878a178de0869", size = 218436, upload-time = "2026-08-03T22:33:45.613Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/66/19b21e3e95522e8df26464527fa1de53f3db43b86ae29dc96df98ca380ef/splunk_soar_sdk-3.28.1-py3-none-any.whl", hash = "sha256:c7df5612c4aa2d425d7f2b76a24cb37b19f9235e8547a7cb3c23a77421507a5c", size = 220186, upload-time = "2026-08-06T22:45:19.039Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
@@ -52,8 +52,8 @@ name = "authlib"
 version = "1.7.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "joserfc", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
+    { name = "joserfc" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
@@ -65,8 +65,8 @@ name = "beautifulsoup4"
 version = "4.13.5"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "soupsieve", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
 wheels = [
@@ -78,7 +78,7 @@ name = "bleach"
 version = "6.4.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
@@ -90,8 +90,8 @@ name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyproject-hooks", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
@@ -112,31 +112,25 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "(implementation_name != 'PyPy' and platform_machine == 'arm64' and sys_platform == 'darwin') or (implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (implementation_name != 'PyPy' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
     { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
     { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
     { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
     { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
     { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
     { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
     { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
     { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
     { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
     { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
     { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
     { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
     { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
@@ -159,42 +153,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c764272
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
     { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
-    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
     { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
     { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
     { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
     { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
     { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
     { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
     { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
     { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
     { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
     { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
     { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
     { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
-    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
     { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
@@ -245,56 +215,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/e6/38c3653ff6d56d704b29241362387ca824e38e15b76fdcb7096538195790/coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a", size = 221068, upload-time = "2026-06-22T23:08:55.571Z" },
     { url = "https://files.pythonhosted.org/packages/82/50/dfce42eff2cecabcd5a9bbad5489449c87db3415f408d23ffee417ce01f6/coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73", size = 254657, upload-time = "2026-06-22T23:08:59.453Z" },
     { url = "https://files.pythonhosted.org/packages/ba/d2/639ceb1bc8038fd0d66768278d5dc22df3391918b8278c2a21aa2602a531/coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9", size = 255892, upload-time = "2026-06-22T23:09:01.291Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/96/002094a10e113512500dc1e10430a449417e17b0f90f7d496bcb820208b7/coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de", size = 258026, upload-time = "2026-06-22T23:09:03.017Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ec/286a5d2fad9c4bee59bd724feeb7d5bf8303c6c9200b51d1dd945a9c72b0/coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd", size = 252285, upload-time = "2026-06-22T23:09:04.773Z" },
     { url = "https://files.pythonhosted.org/packages/d9/7d/a17753a0b12dd48d0d50f5fab079ad99d3be1eac790494d89f3a417ca0b9/coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5", size = 254023, upload-time = "2026-06-22T23:09:06.513Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/39/353013a75fec0fb49f7553519f9d52b4441e902e5178c93f38eb6c07cedb/coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f", size = 256144, upload-time = "2026-06-22T23:09:10.369Z" },
-    { url = "https://files.pythonhosted.org/packages/29/0e/613878555d734def11c5b20a2701a15cb3781b9e9ea749da27c5f436e928/coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498", size = 251808, upload-time = "2026-06-22T23:09:12.057Z" },
     { url = "https://files.pythonhosted.org/packages/af/76/359c058c9cfdcf1e8b107663881225b03b364a320017eda24a2a66e55102/coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0", size = 253579, upload-time = "2026-06-22T23:09:13.858Z" },
     { url = "https://files.pythonhosted.org/packages/61/56/14e3b97facbfa1304dd19e676e26599ad359f04714bed32f7f1c5a88efdc/coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc", size = 220741, upload-time = "2026-06-22T23:09:21.616Z" },
     { url = "https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7", size = 221068, upload-time = "2026-06-22T23:09:23.452Z" },
     { url = "https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5", size = 254622, upload-time = "2026-06-22T23:09:27.523Z" },
     { url = "https://files.pythonhosted.org/packages/c8/25/ec6de51ae7493b92a1cf74d1b763121c29636759167e2a593ba4db5881e4/coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a", size = 255968, upload-time = "2026-06-22T23:09:29.43Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/05/c8bfc77823f42b4664fb25842f13b567022f6f84a4c83c8ecbb16734b7cb/coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501", size = 258284, upload-time = "2026-06-22T23:09:31.397Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/15/1d1b242027124a32b26ef01f82018b8c4ef34ef174aa6aeba7b1eeef48e8/coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e", size = 252143, upload-time = "2026-06-22T23:09:33.256Z" },
     { url = "https://files.pythonhosted.org/packages/74/b6/d2a9842fd2a5d7d27f1ac851c043a734a494ad75402c5331db3da79ed691/coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3", size = 253976, upload-time = "2026-06-22T23:09:35.351Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/2c/9159de64f9dd648e324328d588a44cfab1e331eb5259ce1141afe2a92dfb/coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845", size = 256220, upload-time = "2026-06-22T23:09:39.165Z" },
-    { url = "https://files.pythonhosted.org/packages/91/67/b7f536cc2c124f48e91b22fbb741d2261f4e3d310faf6f76007f47566e5d/coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027", size = 251756, upload-time = "2026-06-22T23:09:41.056Z" },
     { url = "https://files.pythonhosted.org/packages/dd/ec/f3718038e2d4860c715a55428377ca7f6c75872caf98cabd982e1d76967d/coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b", size = 253413, upload-time = "2026-06-22T23:09:43.306Z" },
     { url = "https://files.pythonhosted.org/packages/55/57/017353fab573779c0d00448e47d102edd36c792f7b6f233a4d89a7a08384/coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949", size = 221474, upload-time = "2026-06-22T23:09:51.417Z" },
     { url = "https://files.pythonhosted.org/packages/69/92/90cf1f1a5c468a9c1b7ba2716e0e205293ad9b02f5f573a6de4318b15ba1/coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891", size = 221738, upload-time = "2026-06-22T23:09:53.487Z" },
     { url = "https://files.pythonhosted.org/packages/06/76/e5d33b2576ae3bf2be2058cd1cae57774b61e400f2c3c58f3783dc2ffb4a/coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784", size = 265225, upload-time = "2026-06-22T23:09:57.904Z" },
     { url = "https://files.pythonhosted.org/packages/61/d2/e52419afe391a39ba27fdefaf0737d8e34bf03faef6ab3b3006545bbd0d0/coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed", size = 267643, upload-time = "2026-06-22T23:09:59.938Z" },
-    { url = "https://files.pythonhosted.org/packages/58/7a/f2625d8d5006b6b20fba5afaef00b24a763fe96476ea798a3076cbc1f84e/coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5", size = 268762, upload-time = "2026-06-22T23:10:01.943Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/bf/908024006bba57127354d74e938954b9c3cd765cc2e0412dc9c37b415cda/coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26", size = 262208, upload-time = "2026-06-22T23:10:03.954Z" },
     { url = "https://files.pythonhosted.org/packages/34/a0/d4f9296441b909817442fdb26bd77a698f08272ec683a7394b00eb2e47a0/coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889", size = 265096, upload-time = "2026-06-22T23:10:05.936Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/7a/6927148073ff32856d78baa77b4ddc07a9be7e90020f9db0661c4ca523a1/coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e", size = 266433, upload-time = "2026-06-22T23:10:10.145Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a7/774f658dbe9c4c3f5daa86a87e0459ac3832e4e3cc67affe078547f727b9/coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7", size = 261547, upload-time = "2026-06-22T23:10:12.191Z" },
     { url = "https://files.pythonhosted.org/packages/3d/14/a0c18c0376c43cbf973f43ef6ca20019c950597180e6396232f7b6a27102/coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635", size = 263859, upload-time = "2026-06-22T23:10:14.492Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
 ]
 
 [[package]]
 name = "crowdstrikeoauthapi"
-version = "5.1.4"
+version = "6.0.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytz", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests-toolbelt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "splunk-soar-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "beautifulsoup4" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "splunk-soar-sdk" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "coverage", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "mypy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pre-commit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest-mock", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest-watch", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "coverage" },
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "pytest-watch" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -303,7 +261,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2023.3" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "requests-toolbelt", specifier = "==1.0.0" },
-    { name = "splunk-soar-sdk", specifier = ">=3.26.1" },
+    { name = "splunk-soar-sdk", specifier = ">=3.26.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -322,7 +280,7 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -330,11 +288,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
     { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
     { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
-    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
     { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
     { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
     { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
     { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
     { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
@@ -342,11 +297,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
     { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
     { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
     { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
     { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
     { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
     { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
     { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
@@ -354,11 +306,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
     { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
     { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
-    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
     { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
-    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
     { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
     { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
@@ -410,13 +359,13 @@ name = "extract-msg"
 version = "0.55.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "compressed-rtf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ebcdic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "olefile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "red-black-tree-mod", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rtfde", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tzlocal", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "beautifulsoup4" },
+    { name = "compressed-rtf" },
+    { name = "ebcdic" },
+    { name = "olefile" },
+    { name = "red-black-tree-mod" },
+    { name = "rtfde" },
+    { name = "tzlocal" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/65/c70afb3b119a44b3ee36b029485dc15326cf3a7c50da19a1ecbbf949c5d1/extract_msg-0.55.0.tar.gz", hash = "sha256:cf08283498c3dfcc7f894dad1579f52e3ced9fb76b865c2355cbe757af8a54e1", size = 331170, upload-time = "2025-08-12T16:07:56.537Z" }
 wheels = [
@@ -446,10 +395,10 @@ name = "hatchling"
 version = "1.30.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pathspec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pluggy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "trove-classifiers", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/4c/8717ccb844b4fa5a5ba6352e97d743ed24e9a22cf90b7c109c17030a46a1/hatchling-1.30.1.tar.gz", hash = "sha256:eee4fd45357f72ebb3d7a42e5d72cfb5e29ed426d79e8836288926c4258d5f2e", size = 56929, upload-time = "2026-06-02T00:09:41.487Z" }
 wheels = [
@@ -461,8 +410,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "h11", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -474,10 +423,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpcore", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -489,7 +438,7 @@ name = "httpx-retries"
 version = "0.5.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/f5/046cac13877ce9b55aebdbb3999e0e45b19b989a95c5fd1040fa04bd1f92/httpx_retries-0.5.0.tar.gz", hash = "sha256:d8c8e1e0852d84be3837aba0bcf78aeb89a4b77db95e8cc988c8c058830b3044", size = 15647, upload-time = "2026-04-20T01:21:47.154Z" }
 wheels = [
@@ -537,7 +486,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -549,7 +498,7 @@ name = "joserfc"
 version = "1.7.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
@@ -575,25 +524,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
     { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
     { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
     { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
     { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
     { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
     { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
-    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
     { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
-    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
     { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
     { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
     { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
     { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
-    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
     { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
 ]
 
@@ -602,7 +545,7 @@ name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -619,33 +562,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
     { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
     { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
     { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
     { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
     { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
     { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
     { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
     { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
     { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
     { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
     { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
     { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
     { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
     { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
     { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
     { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
     { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
     { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
     { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
     { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
     { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
 ]
 
@@ -663,8 +598,8 @@ name = "msoffcrypto-tool"
 version = "6.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "olefile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
+    { name = "olefile" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/34/6250bdddaeaae24098e45449ea362fb3555a65fba30cad0ad5630ea48d1a/msoffcrypto_tool-6.0.0.tar.gz", hash = "sha256:9a5ebc4c0096b42e5d7ebc2350afdc92dc511061e935ca188468094fdd032bbe", size = 40593, upload-time = "2026-01-12T08:59:56.73Z" }
 wheels = [
@@ -676,10 +611,10 @@ name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "librt", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
-    { name = "mypy-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pathspec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
@@ -733,12 +668,12 @@ name = "oletools"
 version = "0.60.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "colorclass", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "easygui", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "msoffcrypto-tool", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "olefile", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pcodedmp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyparsing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "colorclass" },
+    { name = "easygui" },
+    { name = "msoffcrypto-tool", marker = "platform_python_implementation != 'PyPy' or sys_platform == 'linux'" },
+    { name = "olefile" },
+    { name = "pcodedmp" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/2f/037f40e44706d542b94a2312ccc33ee2701ebfc9a83b46b55263d49ce55a/oletools-0.60.2.zip", hash = "sha256:ad452099f4695ffd8855113f453348200d195ee9fa341a09e197d66ee7e0b2c3", size = 3433750, upload-time = "2024-07-02T14:50:38.242Z" }
 wheels = [
@@ -768,7 +703,7 @@ name = "pcodedmp"
 version = "1.2.6"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "oletools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "oletools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/20/6d461e29135f474408d0d7f95b2456a9ba245560768ee51b788af10f7429/pcodedmp-1.2.6.tar.gz", hash = "sha256:025f8c809a126f45a082ffa820893e6a8d990d9d7ddb68694b5a9f0a6dbcd955", size = 35549, upload-time = "2019-07-30T18:05:42.516Z" }
 wheels = [
@@ -780,7 +715,7 @@ name = "pip-licenses"
 version = "5.5.5"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "prettytable", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prettytable" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/18/ddd93af610a04f56a51a27095ddfe55238e1ec236f6758730a0d2c0b49f2/pip_licenses-5.5.5.tar.gz", hash = "sha256:60750c006adf7a0910347b726e8ee9fee3bc8d2e7c8307a5c4ec0776c8e2a276", size = 54955, upload-time = "2026-03-28T22:12:56.48Z" }
 wheels = [
@@ -810,11 +745,11 @@ name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "cfgv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "identify", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nodeenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "virtualenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
@@ -826,7 +761,7 @@ name = "prettytable"
 version = "3.18.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
 wheels = [
@@ -847,10 +782,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -862,42 +797,27 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
     { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
     { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
     { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
     { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
-    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
     { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
     { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
     { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
     { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
-    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
-    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
     { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
     { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
     { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
     { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
     { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
     { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
     { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
-    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
     { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
     { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
 ]
 
@@ -921,7 +841,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -947,9 +867,9 @@ name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "iniconfig", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pluggy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
 wheels = [
@@ -961,7 +881,7 @@ name = "pytest-mock"
 version = "3.15.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
@@ -973,10 +893,10 @@ name = "pytest-watch"
 version = "4.2.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "docopt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "watchdog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "colorama" },
+    { name = "docopt" },
+    { name = "pytest" },
+    { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/47/ab65fc1d682befc318c439940f81a0de1026048479f732e84fe714cd69c0/pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9", size = 16340, upload-time = "2018-05-20T19:52:16.194Z" }
 
@@ -985,8 +905,8 @@ name = "python-discovery"
 version = "1.4.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "filelock" },
+    { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
@@ -1011,21 +931,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
     { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
     { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
     { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
     { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
     { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
     { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
     { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
     { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
     { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
     { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
     { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
     { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
     { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
     { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
     { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
@@ -1042,10 +959,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "charset-normalizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "urllib3", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -1057,7 +974,7 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -1066,15 +983,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygments", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -1082,8 +999,8 @@ name = "rtfde"
 version = "0.1.2.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "lark", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "oletools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "lark" },
+    { name = "oletools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/5c/116a016b38af589e8141160bc9b034b73dde2e50c22a921751f4d982a7ca/rtfde-0.1.2.2.tar.gz", hash = "sha256:2f0cd6ecd644071e39452e6fc4f4a1435453af0ec7c90ea86fb4fc96010c7f1b", size = 33408, upload-time = "2025-12-09T17:10:31.805Z" }
 wheels = [
@@ -1096,17 +1013,11 @@ version = "0.15.19"
 source = { registry = "https://pypi.python.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/15800dfde183a1a106594016c912b4c12d050a301989d1aca6cb63759fe8/ruff-0.15.19.tar.gz", hash = "sha256:edc27f7172a93b32b102687009d6a588508815072141543ae603a8b9b0823063", size = 4772071, upload-time = "2026-06-24T01:10:46.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/4c/9ded7626c39a0440c575bf69e2bf500d443388272c842662c59852ee7fcd/ruff-0.15.19-py3-none-linux_armv6l.whl", hash = "sha256:922d1eb283161564759bd49f507e91dc6112c15da8bd5b84ed714e086243cf86", size = 10950859, upload-time = "2026-06-24T01:10:38.491Z" },
     { url = "https://files.pythonhosted.org/packages/fb/ef/c211505ece1d00ef493d58e54e3b6383c946a21e9874774eb531f2512cf3/ruff-0.15.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d190d8f62a0b94aba8f721116538a9ee29b1e74d26650846ba9b99f0ae21c40", size = 11294529, upload-time = "2026-06-24T01:10:36.481Z" },
     { url = "https://files.pythonhosted.org/packages/fe/93/78d462e7d39968e58094dc57be7d09ffb14ce37da5b68ed70338a35a1f21/ruff-0.15.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a2c86ba6870dd415a9d9eb8be94d7924ebec6a26ffc7958ec7ca29d4bff967d", size = 10641416, upload-time = "2026-06-24T01:10:48.923Z" },
     { url = "https://files.pythonhosted.org/packages/76/c4/5cb66cfd1f865d5cca908b86c93ac785e7f572193d3c7426079ca6643e24/ruff-0.15.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b432bc087264aea70fd25ac198918b70bd9e2aa0db4297b0bb91bbfbbc63ce", size = 11015582, upload-time = "2026-06-24T01:10:30.089Z" },
-    { url = "https://files.pythonhosted.org/packages/51/9f/8ecfaec10cf5eecd28fbc00ff4fb867db90a1be54bf3d39ebf93f893cd52/ruff-0.15.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8530a09d03b3a8c994f8b559a7dcdabc690bcd3f78ef276c38c83166798ebf56", size = 10744059, upload-time = "2026-06-24T01:10:32.48Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/39/bc7794f127b18f492a3b4ee82bba5a900c985ff13b72b46f46e3c171ba34/ruff-0.15.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b229cb3ef56ecc2c1c8ebeca64b7a7740ccaef40a9eb097e78dde5a8560b83", size = 12429690, upload-time = "2026-06-24T01:10:40.638Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/3b/0de6859e698ed11c8a49e765196c8d333599b6a546c0715df39b6ba1aa2e/ruff-0.15.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c754515be7b76afe6e7e62df7776709571bcfc1631183828afcf3bafa869e3", size = 11693067, upload-time = "2026-06-24T01:10:25.681Z" },
     { url = "https://files.pythonhosted.org/packages/89/3d/0b1f30f84bee9ae6ae8d349c2ba8b6f4b040966744efdd3acc804ae7c024/ruff-0.15.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a498f82e0f4d8904c4e0aea5139cdfac1f39d19a3c51d491292f63a36e83b2e", size = 11616911, upload-time = "2026-06-24T01:10:44.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/eb/c90bd3dfc12eed9032c2c1bfe05105b93a1b2c8bce555db6308315b853ce/ruff-0.15.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d48caa34488fb521fd0ef4aea2b0e8fe758298df044138f0d67b687a6a0d07ed", size = 11649343, upload-time = "2026-06-24T01:10:23.472Z" },
     { url = "https://files.pythonhosted.org/packages/82/91/01caa13602a2f12fae5edbe8caf78b3c1e6db1293132aee6959eecce095c/ruff-0.15.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4171b6613effa9363cd46dd4f75bd1827b6d1b946b5e278ed0c600d305379445", size = 10977610, upload-time = "2026-06-24T01:10:50.892Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/acb817922feab9ecbb3201377d4dbe7a25f1395e46545820061973f03468/ruff-0.15.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:27c15b2a241dd4d995557949a094fe78b8ad99122a38ccae1595849bcc947b3f", size = 10744900, upload-time = "2026-06-24T01:10:42.726Z" },
     { url = "https://files.pythonhosted.org/packages/81/e0/4a888cbe4d5523b3f77a2b1fa043f46cfeba1b32eac35dcfadee0578fa8a/ruff-0.15.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:08143f0685ae278b30727ea72e90c61e5bd9c31b91aac4f5bb989538f73d24b8", size = 11696533, upload-time = "2026-06-24T01:10:53.046Z" },
 ]
 
@@ -1139,34 +1050,35 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "3.26.1"
+version = "3.26.4"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "authlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "bleach", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "build", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "distro", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "extract-msg", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "hatchling", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx-retries", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "humanize", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pip-licenses", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "setuptools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "toml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "authlib" },
+    { name = "beautifulsoup4" },
+    { name = "bleach" },
+    { name = "build" },
+    { name = "click" },
+    { name = "distro" },
+    { name = "extract-msg" },
+    { name = "hatchling" },
+    { name = "httpx" },
+    { name = "httpx-retries" },
+    { name = "humanize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pip-licenses" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "setuptools" },
+    { name = "toml" },
+    { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/9b/0e1f93ce073820b3915a25c037a56da53c66873c602a82c4d7d3c4240ff9/splunk_soar_sdk-3.26.1.tar.gz", hash = "sha256:221e1ad5dc931d2d821c2161e23a847ceb92a9a7fcc7812b9ad0d9e6714626b7", size = 741680, upload-time = "2026-07-17T16:23:40.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/bd/b10bc6db527312a3996860934611db04c5cca7edeac6a5b53d65f743d2c9/splunk_soar_sdk-3.26.4.tar.gz", hash = "sha256:be21e4bb4193db6e336e376e2ad3efde894d539ca054631bddf6be437925a8dd", size = 746216, upload-time = "2026-07-29T16:59:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/c5/f8db01101ee32a1de0aa8108f3e702e271f966c2ab8dbb410d4ffef7b216/splunk_soar_sdk-3.26.1-py3-none-any.whl", hash = "sha256:3f74edb11023c5910de0f728363cd635083169285a26120691adab9df83f9251", size = 216872, upload-time = "2026-07-17T16:23:38.759Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9e/85782f9e3f1f6f64fe83f2b7f0d838ebdc77c203f7b060bafde215e27e5d/splunk_soar_sdk-3.26.4-py3-none-any.whl", hash = "sha256:c7259cb31212d2497981d1e7a94f8bb79a98b16efb2214a834772a7ceb85190d", size = 217037, upload-time = "2026-07-29T16:59:56.257Z" },
 ]
 
 [[package]]
@@ -1201,10 +1113,10 @@ name = "typer"
 version = "0.17.5"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "shellingham", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/3e/30bff313f4868538330c6254bbbe178d6143e43c6f3e7a34788d381f701c/typer-0.17.5.tar.gz", hash = "sha256:a6fe2d187feb1b4a10322b910267b6339e4cc98257fae34d22299a47eac704f1", size = 103790, upload-time = "2025-09-19T18:34:31.292Z" }
 wheels = [
@@ -1225,7 +1137,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -1255,10 +1167,10 @@ name = "virtualenv"
 version = "21.5.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
-    { name = "distlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "filelock", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-discovery", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
@@ -1275,10 +1187,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
     { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
     { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -49,15 +49,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.2"
+version = "1.7.1"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f2/e05664d5275ce811fd4e9df0a2b3f0086ee19a8a80358d95499fa82fd50c/authlib-1.7.1.tar.gz", hash = "sha256:8c09b0f9d080c823e594b52316af70f79a1fa4eed64d0363a076233c04ef063a", size = 175884, upload-time = "2026-05-04T08:11:25.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/730650ee5e5b598b7bfdc291b784bc2f6fe02a5671695485403365101088/authlib-1.7.1-py2.py3-none-any.whl", hash = "sha256:8470f4aa6b5590ac41bd81d6e6ee12448ce36a0da0af19bbed69fb53fb4e8ad9", size = 258826, upload-time = "2026-05-04T08:11:23.208Z" },
 ]
 
 [[package]]
@@ -261,7 +261,7 @@ requires-dist = [
     { name = "pytz", specifier = ">=2023.3" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "requests-toolbelt", specifier = "==1.0.0" },
-    { name = "splunk-soar-sdk", specifier = ">=3.26.4" },
+    { name = "splunk-soar-sdk", specifier = ">=3.27.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1050,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "3.26.4"
+version = "3.27.2"
 source = { registry = "https://pypi.python.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1076,9 +1076,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/bd/b10bc6db527312a3996860934611db04c5cca7edeac6a5b53d65f743d2c9/splunk_soar_sdk-3.26.4.tar.gz", hash = "sha256:be21e4bb4193db6e336e376e2ad3efde894d539ca054631bddf6be437925a8dd", size = 746216, upload-time = "2026-07-29T16:59:57.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/61/6ee011e2f7cb8a0bc9332aa40b1d8ebd25612d62e720b3cc58cfe9a9c4da/splunk_soar_sdk-3.27.2.tar.gz", hash = "sha256:a9ffc36fd79344ab3acff9087df64a50980a2b40779b0039af53755a910773a4", size = 759706, upload-time = "2026-08-03T22:33:46.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/9e/85782f9e3f1f6f64fe83f2b7f0d838ebdc77c203f7b060bafde215e27e5d/splunk_soar_sdk-3.26.4-py3-none-any.whl", hash = "sha256:c7259cb31212d2497981d1e7a94f8bb79a98b16efb2214a834772a7ceb85190d", size = 217037, upload-time = "2026-07-29T16:59:56.257Z" },
+    { url = "https://files.pythonhosted.org/packages/31/7b/36ca02bf9dd7457c16615aa2914de7556e780e9e5d2c3c90dac237756973/splunk_soar_sdk-3.27.2-py3-none-any.whl", hash = "sha256:a605057e1fea2a27e99f48e1e62fddf4167d59af8b34e8eb9a0878a178de0869", size = 218436, upload-time = "2026-08-03T22:33:45.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This follow-up adapts reliability and data-handling corrections to the SDK-based connector, bounds pagination, tightens remote-action validation, and adopts Splunk SOAR SDK 3.28.1.

## Tracking

- Campaign: ESPM-6636
- PAPP: PAPP-37947
- PSAAS: PSAAS-30563, PSAAS-30738, PSAAS-31125, PSAAS-31539, PSAAS-31811, PSAAS-31814, PSAAS-31835, PSAAS-31873, PSAAS-31874, PSAAS-31994, PSAAS-32064, PSAAS-32145, PSAAS-32174, PSAAS-32235, PSAAS-32304
- VULN: VULN-93288, VULN-93463, VULN-93850, VULN-94264, VULN-94536, VULN-94539, VULN-94559, VULN-94597, VULN-94598, VULN-94718, VULN-94788, VULN-94868, VULN-94897, VULN-94958, VULN-95027

## Validation

- exact head: `69db2dacfc0b7c3ffeb38df5a860db3d66f87b55`
- local pytest (`30 passed`), compile, and full pre-commit: passed
- hosted required gates passed: app-type detection, pre-commit, pytest, compile, build, test setup, coverage, release preview, and AWS CodeBuild integration status
- both `document_password` inputs produce manifest `data_type: password`; SOAR 8.6 encrypts password-typed action targets at rest and redacts password-typed result parameters before persistence, so VULN-94598 / PSAAS-31874 is FIXED at source level while retaining automation datapaths
- SDK 3.28.1 includes the duplicate-container artifact retry correction from https://github.com/phantomcyber/splunk-soar-sdk/pull/241
- remaining shared sanity/integration failures are live-lab or stale-fixture failures and are non-gating for this connector workflow

Merge strategy: merge commit only; do not squash.

Written by Codex for Scott Odle.
